### PR TITLE
Add explicit use of After to select starting row instead of selector

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -129,7 +129,7 @@ func TestBond_Query_OnOrderedIndex(t *testing.T) {
 	assert.Equal(t, tokenBalanceAccount1, tokenBalances[2])
 }
 
-func TestBond_Query_OnOrderedIndex_Selector_Paging(t *testing.T) {
+func TestBond_Query_Last_Row_As_Selector(t *testing.T) {
 	db, TokenBalanceTable, _, lastIndex := setupDatabaseForQuery()
 	defer tearDownDatabase(db)
 
@@ -216,6 +216,169 @@ func TestBond_Query_OnOrderedIndex_Selector_Paging(t *testing.T) {
 	err = query.Execute(&tokenBalances)
 	require.Nil(t, err)
 	require.Equal(t, 0, len(tokenBalances))
+}
+
+func TestBond_Query_After(t *testing.T) {
+	db, TokenBalanceTable, _, lastIndex := setupDatabaseForQuery()
+	defer tearDownDatabase(db)
+
+	TokenBalanceOrderedIndex := NewIndex[*TokenBalance](
+		lastIndex.IndexID+1,
+		func(builder KeyBuilder, tb *TokenBalance) []byte {
+			return builder.AddStringField(tb.AccountAddress).Bytes()
+		},
+		func(o IndexOrder, tb *TokenBalance) IndexOrder {
+			return o.OrderUint64(tb.Balance, IndexOrderTypeDESC)
+		},
+	)
+
+	err := TokenBalanceTable.AddIndex([]*Index[*TokenBalance]{TokenBalanceOrderedIndex})
+	require.NoError(t, err)
+
+	tokenBalanceAccount1 := &TokenBalance{
+		ID:              1,
+		AccountID:       1,
+		ContractAddress: "0xtestContract",
+		AccountAddress:  "0xtestAccount",
+		Balance:         5,
+	}
+
+	tokenBalance2Account1 := &TokenBalance{
+		ID:              2,
+		AccountID:       1,
+		ContractAddress: "0xtestContract2",
+		AccountAddress:  "0xtestAccount",
+		Balance:         15,
+	}
+
+	tokenBalance3Account1 := &TokenBalance{
+		ID:              3,
+		AccountID:       1,
+		ContractAddress: "0xtestContract3",
+		AccountAddress:  "0xtestAccount",
+		Balance:         7,
+	}
+
+	tokenBalance1Account2 := &TokenBalance{
+		ID:              4,
+		AccountID:       2,
+		ContractAddress: "0xtestContract",
+		AccountAddress:  "0xtestAccount2",
+		Balance:         4,
+	}
+
+	err = TokenBalanceTable.Insert(
+		[]*TokenBalance{
+			tokenBalanceAccount1,
+			tokenBalance2Account1,
+			tokenBalance3Account1,
+			tokenBalance1Account2,
+		},
+	)
+	require.NoError(t, err)
+
+	var tokenBalances []*TokenBalance
+
+	query := TokenBalanceTable.Query().
+		With(TokenBalanceOrderedIndex, &TokenBalance{AccountAddress: "0xtestAccount", Balance: math.MaxUint64})
+
+	err = query.Execute(&tokenBalances)
+	require.Nil(t, err)
+	require.Equal(t, 3, len(tokenBalances))
+
+	assert.Equal(t, tokenBalance2Account1, tokenBalances[0])
+	assert.Equal(t, tokenBalance3Account1, tokenBalances[1])
+	assert.Equal(t, tokenBalanceAccount1, tokenBalances[2])
+
+	query = TokenBalanceTable.Query().
+		With(TokenBalanceOrderedIndex, &TokenBalance{AccountAddress: "0xtestAccount", Balance: math.MaxUint64}).
+		After(tokenBalances[1])
+
+	err = query.Execute(&tokenBalances)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(tokenBalances))
+
+	assert.Equal(t, tokenBalanceAccount1, tokenBalances[0])
+
+	query = TokenBalanceTable.Query().
+		With(TokenBalanceOrderedIndex, &TokenBalance{AccountAddress: "0xtestAccount", Balance: math.MaxUint64}).
+		After(tokenBalances[0])
+
+	err = query.Execute(&tokenBalances)
+	require.Nil(t, err)
+	require.Equal(t, 0, len(tokenBalances))
+}
+
+func TestBond_Query_After_With_Order_Error(t *testing.T) {
+	db, TokenBalanceTable, _, lastIndex := setupDatabaseForQuery()
+	defer tearDownDatabase(db)
+
+	TokenBalanceOrderedIndex := NewIndex[*TokenBalance](
+		lastIndex.IndexID+1,
+		func(builder KeyBuilder, tb *TokenBalance) []byte {
+			return builder.AddStringField(tb.AccountAddress).Bytes()
+		},
+		func(o IndexOrder, tb *TokenBalance) IndexOrder {
+			return o.OrderUint64(tb.Balance, IndexOrderTypeDESC)
+		},
+	)
+
+	err := TokenBalanceTable.AddIndex([]*Index[*TokenBalance]{TokenBalanceOrderedIndex})
+	require.NoError(t, err)
+
+	tokenBalanceAccount1 := &TokenBalance{
+		ID:              1,
+		AccountID:       1,
+		ContractAddress: "0xtestContract",
+		AccountAddress:  "0xtestAccount",
+		Balance:         5,
+	}
+
+	tokenBalance2Account1 := &TokenBalance{
+		ID:              2,
+		AccountID:       1,
+		ContractAddress: "0xtestContract2",
+		AccountAddress:  "0xtestAccount",
+		Balance:         15,
+	}
+
+	tokenBalance3Account1 := &TokenBalance{
+		ID:              3,
+		AccountID:       1,
+		ContractAddress: "0xtestContract3",
+		AccountAddress:  "0xtestAccount",
+		Balance:         7,
+	}
+
+	tokenBalance1Account2 := &TokenBalance{
+		ID:              4,
+		AccountID:       2,
+		ContractAddress: "0xtestContract",
+		AccountAddress:  "0xtestAccount2",
+		Balance:         4,
+	}
+
+	err = TokenBalanceTable.Insert(
+		[]*TokenBalance{
+			tokenBalanceAccount1,
+			tokenBalance2Account1,
+			tokenBalance3Account1,
+			tokenBalance1Account2,
+		},
+	)
+	require.NoError(t, err)
+
+	var tokenBalances []*TokenBalance
+
+	query := TokenBalanceTable.Query().
+		With(TokenBalanceOrderedIndex, &TokenBalance{AccountAddress: "0xtestAccount", Balance: math.MaxUint64}).
+		After(tokenBalance2Account1).
+		Order(func(tb *TokenBalance, tb2 *TokenBalance) bool {
+			return tb.ID < tb2.ID
+		})
+
+	err = query.Execute(&tokenBalances)
+	require.Error(t, err)
 }
 
 func TestBond_Query_Where(t *testing.T) {


### PR DESCRIPTION
Note: Using selector as the indicator of first row is still allowed, however discouraged.