### PR TITLE
enhancement: collect block metadata to filter primary keys

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Build Example
       run: go build -v ./_examples/simple/...

--- a/batch.go
+++ b/batch.go
@@ -107,7 +107,11 @@ func (b *_batch) DeleteRange(start []byte, end []byte, opt WriteOptions, _ ...Ba
 }
 
 func (b *_batch) Iter(opt *IterOptions, _ ...Batch) Iterator {
-	return b.NewIter(pebbleIterOptions(opt))
+	return &BondIterator{
+		Iterator: b.NewIter(pebbleIterOptions(opt)),
+		batch:    b,
+		filter:   opt.Filter,
+	}
 }
 
 func (b *_batch) Apply(batch Batch, opt WriteOptions) error {

--- a/batch.go
+++ b/batch.go
@@ -107,9 +107,12 @@ func (b *_batch) DeleteRange(start []byte, end []byte, opt WriteOptions, _ ...Ba
 }
 
 func (b *_batch) Iter(opt *IterOptions, _ ...Batch) Iterator {
+	if opt == nil {
+		opt = &IterOptions{}
+	}
+	opt.Batch = b
 	return &BondIterator{
 		Iterator: b.NewIter(pebbleIterOptions(opt)),
-		batch:    b,
 		filter:   opt.Filter,
 		opt:      opt,
 	}

--- a/batch.go
+++ b/batch.go
@@ -111,6 +111,7 @@ func (b *_batch) Iter(opt *IterOptions, _ ...Batch) Iterator {
 		Iterator: b.NewIter(pebbleIterOptions(opt)),
 		batch:    b,
 		filter:   opt.Filter,
+		opt:      opt,
 	}
 }
 

--- a/bond.go
+++ b/bond.go
@@ -160,6 +160,7 @@ func (db *_db) Iter(opt *IterOptions, batch ...Batch) Iterator {
 		return &BondIterator{
 			Iterator: db.pebble.NewIter(pebbleIterOptions(opt)),
 			filter:   opt.Filter,
+			opt:      opt,
 		}
 	}
 }

--- a/bond.go
+++ b/bond.go
@@ -157,7 +157,10 @@ func (db *_db) Iter(opt *IterOptions, batch ...Batch) Iterator {
 	if batch != nil && len(batch) > 0 && batch[0] != nil {
 		return batch[0].Iter(opt)
 	} else {
-		return db.pebble.NewIter(pebbleIterOptions(opt))
+		return &BondIterator{
+			Iterator: db.pebble.NewIter(pebbleIterOptions(opt)),
+			filter:   opt.Filter,
+		}
 	}
 }
 

--- a/cmd/tools/immense_bench/main.go
+++ b/cmd/tools/immense_bench/main.go
@@ -125,8 +125,8 @@ func insertRecords(db bond.DB, batchSize, totalBatch int, wg *sync.WaitGroup) {
 			entries = append(entries, &TokenBalance{
 				ID:              id,
 				AccountID:       uint32(id % 10),
-				ContractAddress: "0xtestContract" + fmt.Sprintf("%d", id),
-				AccountAddress:  "0xtestAccount" + fmt.Sprintf("%d", id%5),
+				ContractAddress: RandStringRunes(20),
+				AccountAddress:  RandStringRunes(20),
 				Balance:         uint64((id % 100) * 10),
 			})
 		}
@@ -216,4 +216,18 @@ func runBondInsert(totalTable, totalBatch, batchSize int) {
 	wg.Wait()
 	elapsed := time.Since(start)
 	fmt.Printf("Total time taken to insert %s \n", elapsed)
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func RandStringRunes(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
 }

--- a/cmd/tools/immense_bench/main.go
+++ b/cmd/tools/immense_bench/main.go
@@ -187,7 +187,7 @@ func main() {
 			},
 			&cli.IntFlag{
 				Name:  "total_batch",
-				Value: 25000,
+				Value: 5000,
 				Usage: "number of batch",
 			},
 			&cli.IntFlag{

--- a/cmd/tools/immense_bench/main.go
+++ b/cmd/tools/immense_bench/main.go
@@ -159,7 +159,7 @@ func main() {
 		Flags: []cli.Flag{
 			&cli.IntFlag{
 				Name:  "batch_size",
-				Value: 100,
+				Value: 20,
 				Usage: "size of the batch",
 			},
 			&cli.IntFlag{

--- a/cmd/tools/immense_bench/main.go
+++ b/cmd/tools/immense_bench/main.go
@@ -188,7 +188,7 @@ func main() {
 			},
 			&cli.IntFlag{
 				Name:  "total_batch",
-				Value: 1000,
+				Value: 8000,
 				Usage: "number of batch",
 			},
 			&cli.IntFlag{

--- a/cmd/tools/immense_bench/main.go
+++ b/cmd/tools/immense_bench/main.go
@@ -237,6 +237,7 @@ func main() {
 			}
 
 			defer func() {
+				db.Close()
 				sz, _ := DirSize("example")
 				fmt.Printf("size of database %s \n", humanize.Bytes(sz))
 				_ = os.RemoveAll("example")

--- a/cmd/tools/immense_bench/main.go
+++ b/cmd/tools/immense_bench/main.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"runtime/pprof"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -187,7 +188,7 @@ func main() {
 			},
 			&cli.IntFlag{
 				Name:  "total_batch",
-				Value: 1000,
+				Value: 8000,
 				Usage: "number of batch",
 			},
 			&cli.IntFlag{
@@ -200,8 +201,36 @@ func main() {
 				Value: false,
 				Usage: "run bondRead",
 			},
+			&cli.BoolFlag{
+				Name:  "pprof",
+				Value: false,
+				Usage: "run pprof",
+			},
 		},
 		Action: func(cCtx *cli.Context) error {
+
+			if cCtx.Bool("pprof") {
+				var (
+					cpuProfile *os.File
+					memProfile *os.File
+					err        error
+				)
+
+				cpuProfile, err = os.Create("cpuprofile")
+				if err != nil {
+					panic(err)
+				}
+				memProfile, err = os.Create("memprofile")
+				if err != nil {
+					panic(err)
+				}
+				fmt.Println("Profiling started")
+				pprof.StartCPUProfile(cpuProfile)
+
+				defer pprof.StopCPUProfile()
+				defer pprof.WriteHeapProfile(memProfile)
+			}
+
 			db, err := bond.Open("example", &bond.Options{})
 			if err != nil {
 				panic(err)

--- a/cmd/tools/immense_bench/main.go
+++ b/cmd/tools/immense_bench/main.go
@@ -182,7 +182,7 @@ func main() {
 		Flags: []cli.Flag{
 			&cli.IntFlag{
 				Name:  "batch_size",
-				Value: 20,
+				Value: 100,
 				Usage: "size of the batch",
 			},
 			&cli.IntFlag{

--- a/cmd/tools/immense_bench/main.go
+++ b/cmd/tools/immense_bench/main.go
@@ -188,7 +188,7 @@ func main() {
 			},
 			&cli.IntFlag{
 				Name:  "total_batch",
-				Value: 8000,
+				Value: 1000,
 				Usage: "number of batch",
 			},
 			&cli.IntFlag{

--- a/cmd/tools/immense_bench/main.go
+++ b/cmd/tools/immense_bench/main.go
@@ -187,7 +187,7 @@ func main() {
 			},
 			&cli.IntFlag{
 				Name:  "total_batch",
-				Value: 5000,
+				Value: 1000,
 				Usage: "number of batch",
 			},
 			&cli.IntFlag{

--- a/cmd/tools/immense_bench/main.go
+++ b/cmd/tools/immense_bench/main.go
@@ -187,7 +187,7 @@ func main() {
 			},
 			&cli.IntFlag{
 				Name:  "total_batch",
-				Value: 8000,
+				Value: 25000,
 				Usage: "number of batch",
 			},
 			&cli.IntFlag{

--- a/collector.go
+++ b/collector.go
@@ -1,0 +1,169 @@
+package bond
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"sync"
+
+	"github.com/cockroachdb/pebble"
+
+	"github.com/cockroachdb/pebble/sstable"
+)
+
+var (
+	BlockCollectorID = "bc"
+)
+
+type KeyMeta struct {
+	Max []byte
+	Min []byte
+}
+
+var keyMetaPool = &sync.Pool{
+	New: func() any {
+		return &KeyMeta{}
+	},
+}
+
+type BlockMeta struct {
+	Properties map[TableID]*KeyMeta
+}
+
+func NewBlockMeta() *BlockMeta {
+	return &BlockMeta{
+		Properties: make(map[TableID]*KeyMeta, 4),
+	}
+}
+
+func (b *BlockMeta) Encode(buf []byte) []byte {
+	// block meta encoded as:
+	// TableID | minKeyLen | minKey | maxKeyLen | maxKey | TableID | ...
+	lenBuf := make([]byte, 4)
+	buff := bytes.NewBuffer(buf)
+	for tableID, property := range b.Properties {
+		buff.WriteByte(byte(tableID))
+		binary.BigEndian.PutUint32(lenBuf, uint32(len(property.Min)))
+		buff.Write(lenBuf)
+		buff.Write(property.Min)
+		binary.BigEndian.PutUint32(lenBuf, uint32(len(property.Max)))
+		buff.Write(lenBuf)
+		buff.Write(property.Max)
+		keyMetaPool.Put(property)
+		delete(b.Properties, tableID)
+	}
+
+	return buff.Bytes()
+}
+
+func (b *BlockMeta) Decode(buf []byte) {
+	if len(buf) == 0 {
+		return
+	}
+
+	buff := bytes.NewBuffer(buf)
+
+	for {
+		tableID, err := buff.ReadByte()
+		if err == io.EOF {
+			return
+		}
+		meta := keyMetaPool.Get().(*KeyMeta)
+		lenBuf := buff.Next(4)
+		keyLen := binary.BigEndian.Uint32(lenBuf)
+		meta.Min = buff.Next(int(keyLen))
+
+		lenBuf = buff.Next(4)
+		keyLen = binary.BigEndian.Uint32(lenBuf)
+		meta.Max = buff.Next(int(keyLen))
+		b.Properties[TableID(tableID)] = meta
+	}
+
+}
+
+type BlockCollector struct {
+	*BlockMeta
+}
+
+// Add implements sstable.BlockPropertyCollector
+func (b *BlockCollector) Add(pebbleKey sstable.InternalKey, value []byte) error {
+	if pebbleKey.Trailer != uint64(pebble.InternalKeyKindSet) {
+		return nil
+	}
+
+	key := KeyBytes(pebbleKey.UserKey)
+	if key.IndexID() != PrimaryIndexID {
+		return nil
+	}
+
+	tableID := key.TableID()
+	primaryKey := key.PrimaryKey()
+
+	meta, ok := b.BlockMeta.Properties[tableID]
+	if !ok {
+		meta := keyMetaPool.Get().(*KeyMeta)
+		meta.Min = primaryKey
+		meta.Max = primaryKey
+		b.BlockMeta.Properties[tableID] = meta
+		return nil
+	}
+
+	if bytes.Compare(meta.Min, primaryKey) < 0 {
+		meta.Max = primaryKey
+		return nil
+	}
+	meta.Max = meta.Min
+	meta.Min = primaryKey
+	return nil
+}
+
+// AddPrevDataBlockToIndexBlock implements sstable.BlockPropertyCollector
+func (*BlockCollector) AddPrevDataBlockToIndexBlock() {
+}
+
+// FinishDataBlock implements sstable.BlockPropertyCollector
+func (b *BlockCollector) FinishDataBlock(buf []byte) ([]byte, error) {
+	return b.Encode(buf), nil
+}
+
+// FinishIndexBlock implements sstable.BlockPropertyCollector
+func (*BlockCollector) FinishIndexBlock(buf []byte) ([]byte, error) {
+	return buf, nil
+}
+
+// FinishTable implements sstable.BlockPropertyCollector
+func (*BlockCollector) FinishTable(buf []byte) ([]byte, error) {
+	return buf, nil
+}
+
+// Name implements sstable.BlockPropertyCollector
+func (*BlockCollector) Name() string {
+	return BlockCollectorID
+}
+
+var _ pebble.BlockPropertyCollector = &BlockCollector{}
+
+type PrimaryKeyFilter struct {
+	ID  TableID
+	Key []byte
+	*BlockMeta
+}
+
+// Intersects implements base.BlockPropertyFilter
+func (p *PrimaryKeyFilter) Intersects(prop []byte) (bool, error) {
+	p.Decode(prop)
+
+	meta, ok := p.Properties[p.ID]
+	if !ok {
+		return false, nil
+	}
+
+	return (bytes.Compare(meta.Min, p.Key) <= 0 && bytes.Compare(meta.Max, p.Key) >= 0), nil
+}
+
+// Name implements base.BlockPropertyFilter
+func (*PrimaryKeyFilter) Name() string {
+	return BlockCollectorID
+}
+
+var _ pebble.BlockPropertyFilter = &PrimaryKeyFilter{}

--- a/collector.go
+++ b/collector.go
@@ -65,6 +65,7 @@ func (b *KeyRange) Encode(buf []byte) []byte {
 }
 
 func (b *KeyRange) Decode(buf []byte) {
+	b.Ranges = make(map[TableID]*Range)
 	if len(buf) == 0 {
 		return
 	}

--- a/collector.go
+++ b/collector.go
@@ -15,7 +15,7 @@ import (
 var (
 	BlockCollectorID = "bc"
 	// Primary Key does not contain Index Key and Index Order Key. So, it's guaranteed that Primary Key
-	// begin at the index `10`.
+	// begins at the index `10`.
 	PrimaryKeyStartIdx = 10
 )
 
@@ -24,7 +24,7 @@ type Range struct {
 	Min []byte
 }
 
-// key ranges of a particular SST table's block. It's encoded as block property for pebble to
+// key ranges of a particular SST table's block. It's encoded as a block property for pebble to
 // store it along with the SST table, by following the given raw byte scheme:
 // TableID | minKeyLen | minKey | maxKeyLen | maxKey | TableID | ...
 type KeyRange struct {
@@ -179,7 +179,7 @@ func (p *PrimaryKeyFilter) Intersects(prop []byte) (bool, error) {
 		return false, nil
 	}
 	// It's efficient to use raw bytes while intersecting `KeyRange` instead
-	// using `KeyRange.Decode`
+	// of using `KeyRange.Decode`
 	buff := bytes.NewBuffer(prop)
 	for {
 		// TableID

--- a/collector.go
+++ b/collector.go
@@ -52,7 +52,6 @@ func (b *BlockMeta) Encode(buf []byte) []byte {
 		keyMetaPool.Put(property)
 		delete(b.Properties, tableID)
 	}
-
 	return buff.Bytes()
 }
 
@@ -78,7 +77,6 @@ func (b *BlockMeta) Decode(buf []byte) {
 		meta.Max = buff.Next(int(keyLen))
 		b.Properties[TableID(tableID)] = meta
 	}
-
 }
 
 type BlockCollector struct {

--- a/collector.go
+++ b/collector.go
@@ -80,11 +80,11 @@ func (b *KeyRange) Decode(buf []byte) {
 		keyRange := &Range{}
 		lenBuf := buff.Next(4)
 		keyLen := binary.BigEndian.Uint32(lenBuf)
-		keyRange.Min = buff.Next(int(keyLen))
+		keyRange.Min = utils.Copy(keyRange.Min, buff.Next(int(keyLen)))
 
 		lenBuf = buff.Next(4)
 		keyLen = binary.BigEndian.Uint32(lenBuf)
-		keyRange.Max = buff.Next(int(keyLen))
+		keyRange.Max = utils.Copy(keyRange.Max, buff.Next(int(keyLen)))
 		b.Ranges[TableID(tableID)] = keyRange
 	}
 }
@@ -109,8 +109,8 @@ func (b *BlockCollector) Add(pebbleKey sstable.InternalKey, value []byte) error 
 	keyRange, ok := b.blockRange.Ranges[tableID]
 	if !ok {
 		keyRange := &Range{}
-		utils.Copy(keyRange.Min, pebbleKey.UserKey)
-		utils.Copy(keyRange.Max, pebbleKey.UserKey)
+		keyRange.Min = utils.Copy(keyRange.Min, pebbleKey.UserKey)
+		keyRange.Max = utils.Copy(keyRange.Max, pebbleKey.UserKey)
 		b.blockRange.Ranges[tableID] = keyRange
 		return nil
 	}

--- a/collector.go
+++ b/collector.go
@@ -109,14 +109,14 @@ func (b *BlockCollector) Add(pebbleKey sstable.InternalKey, value []byte) error 
 	keyRange, ok := b.blockRange.Ranges[tableID]
 	if !ok {
 		keyRange := &Range{}
-		keyRange.Min = utils.Copy(keyRange.Min, pebbleKey.UserKey)
-		keyRange.Max = utils.Copy(keyRange.Max, pebbleKey.UserKey)
+		keyRange.Min = utils.Copy(keyRange.Min, key.PrimaryKey())
+		keyRange.Max = utils.Copy(keyRange.Max, key.PrimaryKey())
 		b.blockRange.Ranges[tableID] = keyRange
 		return nil
 	}
 
-	if bytes.Compare(keyRange.Min, pebbleKey.UserKey) <= 0 {
-		keyRange.Max = utils.Copy(keyRange.Max, pebbleKey.UserKey)
+	if bytes.Compare(keyRange.Min, key.PrimaryKey()) <= 0 {
+		keyRange.Max = utils.Copy(keyRange.Max, key.PrimaryKey())
 		b.blockRange.Ranges[tableID] = keyRange
 		return nil
 	}

--- a/collector.go
+++ b/collector.go
@@ -162,13 +162,12 @@ var _ pebble.BlockPropertyCollector = &BlockCollector{}
 type PrimaryKeyFilter struct {
 	ID   TableID
 	Keys [][]byte
-	*KeyRange
 }
 
-func NewPrimaryKeyFilter(id TableID) *PrimaryKeyFilter {
+func NewPrimaryKeyFilter(id TableID, keys [][]byte) *PrimaryKeyFilter {
 	return &PrimaryKeyFilter{
-		KeyRange: NewKeyRange(),
-		ID:       id,
+		ID:   id,
+		Keys: keys,
 	}
 }
 

--- a/collector.go
+++ b/collector.go
@@ -24,7 +24,7 @@ type Range struct {
 	Min []byte
 }
 
-// key ranges of a particular block. It's encoded as block property for pebble to
+// key ranges of a particular SST table's block. It's encoded as block property for pebble to
 // store it along with the SST table, by following the given raw byte scheme:
 // TableID | minKeyLen | minKey | maxKeyLen | maxKey | TableID | ...
 type KeyRange struct {

--- a/collector_test.go
+++ b/collector_test.go
@@ -189,4 +189,29 @@ func TestFilter(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, err)
 	require.Equal(t, true, intersects)
+
+	filter.Keys = [][]byte{key(2, 1).UserKey, key(2, 34).UserKey, key(2, 42).UserKey}
+	intersects, err = filter.Intersects(encoded)
+	require.NoError(t, err)
+	require.NoError(t, err)
+	require.Equal(t, true, intersects)
+
+	filter.Keys = [][]byte{key(2, 1).UserKey, key(2, 42).UserKey}
+	intersects, err = filter.Intersects(encoded)
+	require.NoError(t, err)
+	require.NoError(t, err)
+	require.Equal(t, false, intersects)
+
+	filter.Keys = [][]byte{key(2, 3).UserKey, key(2, 42).UserKey}
+	intersects, err = filter.Intersects(encoded)
+	require.NoError(t, err)
+	require.NoError(t, err)
+	require.Equal(t, true, intersects)
+
+	filter.Keys = [][]byte{key(3, 40).UserKey}
+	filter.ID = 3
+	intersects, err = filter.Intersects(encoded)
+	require.NoError(t, err)
+	require.NoError(t, err)
+	require.Equal(t, false, intersects)
 }

--- a/collector_test.go
+++ b/collector_test.go
@@ -167,24 +167,24 @@ func TestFilter(t *testing.T) {
 	encoded := keyRange.Encode([]byte{})
 
 	filter := NewPrimaryKeyFilter(1)
-	filter.Key = key(1, 3).UserKey
+	filter.Keys = [][]byte{key(1, 3).UserKey}
 	intersects, err := filter.Intersects(encoded)
 	require.NoError(t, err)
 	require.Equal(t, true, intersects)
 
-	filter.Key = key(1, 11).UserKey
+	filter.Keys = [][]byte{key(1, 11).UserKey}
 	intersects, err = filter.Intersects(encoded)
 	require.NoError(t, err)
 	require.NoError(t, err)
 	require.Equal(t, false, intersects)
 
 	filter = NewPrimaryKeyFilter(2)
-	filter.Key = key(2, 48).UserKey
+	filter.Keys = [][]byte{key(2, 48).UserKey}
 	intersects, err = filter.Intersects(encoded)
 	require.NoError(t, err)
 	require.Equal(t, false, intersects)
 
-	filter.Key = key(3, 40).UserKey
+	filter.Keys = [][]byte{key(3, 40).UserKey}
 	intersects, err = filter.Intersects(encoded)
 	require.NoError(t, err)
 	require.NoError(t, err)

--- a/collector_test.go
+++ b/collector_test.go
@@ -1,0 +1,132 @@
+package bond
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/sstable"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollector(t *testing.T) {
+	encodeNum := func(i uint64) []byte {
+		buf := make([]byte, 8)
+		binary.BigEndian.PutUint64(buf, i)
+		return buf
+	}
+
+	key := func(tID TableID, i uint64) sstable.InternalKey {
+		buf := encodeNum(i)
+		k := KeyEncode(Key{
+			PrimaryKey: buf,
+			TableID:    tID,
+			IndexID:    PrimaryIndexID,
+			IndexKey:   []byte{},
+			IndexOrder: []byte{},
+		})
+		return sstable.InternalKey{
+			UserKey: k,
+			Trailer: (1 << 8) | uint64(pebble.InternalKeyKindSet),
+		}
+	}
+
+	collector := &BlockCollector{
+		tableRange: NewKeyRange(),
+		indexRange: NewKeyRange(),
+		blockRange: NewKeyRange(),
+	}
+
+	require.NoError(t, collector.Add(key(1, 1), []byte{}))
+	require.NoError(t, collector.Add(key(2, 2), []byte{}))
+	require.NoError(t, collector.Add(key(1, 5), []byte{}))
+	require.NoError(t, collector.Add(key(2, 8), []byte{}))
+	require.NoError(t, collector.Add(key(3, 1), []byte{}))
+	require.NoError(t, collector.Add(key(2, 9), []byte{}))
+	require.NoError(t, collector.Add(key(1, 6), []byte{}))
+	require.NoError(t, collector.Add(key(1, 8), []byte{}))
+
+	_, err := collector.FinishDataBlock([]byte{})
+	require.NoError(t, err)
+	require.Equal(t, encodeNum(1), collector.blockRange.Ranges[1].Min)
+	require.Equal(t, encodeNum(8), collector.blockRange.Ranges[1].Max)
+	require.Equal(t, encodeNum(2), collector.blockRange.Ranges[2].Min)
+	require.Equal(t, encodeNum(9), collector.blockRange.Ranges[2].Max)
+	require.Equal(t, encodeNum(1), collector.blockRange.Ranges[3].Min)
+	require.Equal(t, encodeNum(1), collector.blockRange.Ranges[3].Max)
+
+	collector.AddPrevDataBlockToIndexBlock()
+	require.Equal(t, len(collector.blockRange.Ranges), 0)
+	require.Equal(t, encodeNum(1), collector.indexRange.Ranges[1].Min)
+	require.Equal(t, encodeNum(8), collector.indexRange.Ranges[1].Max)
+	require.Equal(t, encodeNum(2), collector.indexRange.Ranges[2].Min)
+	require.Equal(t, encodeNum(9), collector.indexRange.Ranges[2].Max)
+	require.Equal(t, encodeNum(1), collector.indexRange.Ranges[3].Min)
+	require.Equal(t, encodeNum(1), collector.indexRange.Ranges[3].Max)
+
+	require.NoError(t, collector.Add(key(1, 10), []byte{}))
+	require.NoError(t, collector.Add(key(2, 10), []byte{}))
+	require.NoError(t, collector.Add(key(1, 12), []byte{}))
+	require.NoError(t, collector.Add(key(2, 13), []byte{}))
+	require.NoError(t, collector.Add(key(3, 4), []byte{}))
+	require.NoError(t, collector.Add(key(2, 16), []byte{}))
+	require.NoError(t, collector.Add(key(1, 18), []byte{}))
+	require.NoError(t, collector.Add(key(1, 20), []byte{}))
+
+	_, err = collector.FinishDataBlock([]byte{})
+	require.NoError(t, err)
+	require.Equal(t, encodeNum(10), collector.blockRange.Ranges[1].Min)
+	require.Equal(t, encodeNum(20), collector.blockRange.Ranges[1].Max)
+	require.Equal(t, encodeNum(10), collector.blockRange.Ranges[2].Min)
+	require.Equal(t, encodeNum(16), collector.blockRange.Ranges[2].Max)
+	require.Equal(t, encodeNum(4), collector.blockRange.Ranges[3].Min)
+	require.Equal(t, encodeNum(4), collector.blockRange.Ranges[3].Max)
+
+	collector.AddPrevDataBlockToIndexBlock()
+	require.Equal(t, len(collector.blockRange.Ranges), 0)
+	require.Equal(t, encodeNum(1), collector.indexRange.Ranges[1].Min)
+	require.Equal(t, encodeNum(20), collector.indexRange.Ranges[1].Max)
+	require.Equal(t, encodeNum(2), collector.indexRange.Ranges[2].Min)
+	require.Equal(t, encodeNum(16), collector.indexRange.Ranges[2].Max)
+	require.Equal(t, encodeNum(1), collector.indexRange.Ranges[3].Min)
+	require.Equal(t, encodeNum(4), collector.indexRange.Ranges[3].Max)
+
+	_, err = collector.FinishIndexBlock([]byte{})
+	require.NoError(t, err)
+	require.Equal(t, len(collector.indexRange.Ranges), 0)
+	require.Equal(t, encodeNum(1), collector.tableRange.Ranges[1].Min)
+	require.Equal(t, encodeNum(20), collector.tableRange.Ranges[1].Max)
+	require.Equal(t, encodeNum(2), collector.tableRange.Ranges[2].Min)
+	require.Equal(t, encodeNum(16), collector.tableRange.Ranges[2].Max)
+	require.Equal(t, encodeNum(1), collector.tableRange.Ranges[3].Min)
+	require.Equal(t, encodeNum(4), collector.tableRange.Ranges[3].Max)
+
+	require.NoError(t, collector.Add(key(1, 21), []byte{}))
+	require.NoError(t, collector.Add(key(2, 17), []byte{}))
+	require.NoError(t, collector.Add(key(1, 22), []byte{}))
+	require.NoError(t, collector.Add(key(2, 19), []byte{}))
+	require.NoError(t, collector.Add(key(3, 7), []byte{}))
+	require.NoError(t, collector.Add(key(2, 21), []byte{}))
+	require.NoError(t, collector.Add(key(1, 25), []byte{}))
+	require.NoError(t, collector.Add(key(1, 26), []byte{}))
+
+	_, err = collector.FinishDataBlock([]byte{})
+	require.NoError(t, err)
+	require.Equal(t, encodeNum(21), collector.blockRange.Ranges[1].Min)
+	require.Equal(t, encodeNum(26), collector.blockRange.Ranges[1].Max)
+	require.Equal(t, encodeNum(17), collector.blockRange.Ranges[2].Min)
+	require.Equal(t, encodeNum(21), collector.blockRange.Ranges[2].Max)
+	require.Equal(t, encodeNum(7), collector.blockRange.Ranges[3].Min)
+	require.Equal(t, encodeNum(7), collector.blockRange.Ranges[3].Max)
+
+	collector.AddPrevDataBlockToIndexBlock()
+	_, err = collector.FinishTable([]byte{})
+	require.NoError(t, err)
+	require.Equal(t, len(collector.indexRange.Ranges), 0)
+	require.Equal(t, encodeNum(1), collector.tableRange.Ranges[1].Min)
+	require.Equal(t, encodeNum(26), collector.tableRange.Ranges[1].Max)
+	require.Equal(t, encodeNum(2), collector.tableRange.Ranges[2].Min)
+	require.Equal(t, encodeNum(21), collector.tableRange.Ranges[2].Max)
+	require.Equal(t, encodeNum(1), collector.tableRange.Ranges[3].Min)
+	require.Equal(t, encodeNum(7), collector.tableRange.Ranges[3].Max)
+}

--- a/collector_test.go
+++ b/collector_test.go
@@ -166,8 +166,7 @@ func TestFilter(t *testing.T) {
 	}
 	encoded := keyRange.Encode([]byte{})
 
-	filter := NewPrimaryKeyFilter(1)
-	filter.Keys = [][]byte{key(1, 3).UserKey}
+	filter := NewPrimaryKeyFilter(1, [][]byte{key(1, 3).UserKey})
 	intersects, err := filter.Intersects(encoded)
 	require.NoError(t, err)
 	require.Equal(t, true, intersects)
@@ -178,8 +177,7 @@ func TestFilter(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, false, intersects)
 
-	filter = NewPrimaryKeyFilter(2)
-	filter.Keys = [][]byte{key(2, 48).UserKey}
+	filter = NewPrimaryKeyFilter(2, [][]byte{key(2, 48).UserKey})
 	intersects, err = filter.Intersects(encoded)
 	require.NoError(t, err)
 	require.Equal(t, false, intersects)

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/cockroachdb/redact v1.1.3 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165 // indirect
 	github.com/getsentry/sentry-go v0.14.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
@@ -36,6 +37,7 @@ require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/panmari/cuckoofilter v1.0.3 // indirect
 	github.com/philhofer/fwd v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165 h1:BS21ZUJ/B5X2UVUbczfmdWH7GapPWAhxcMsDnjJTU1E=
+github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
@@ -188,6 +190,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
@@ -317,6 +320,8 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/panmari/cuckoofilter v1.0.3 h1:MgTxXG2aP0YPWFyY1sKt1caWidUFREk9BaOnakDKZOU=
+github.com/panmari/cuckoofilter v1.0.3/go.mod h1:O7+ZOHxwlADJ1So2/ZsKBExDwILNPZsyt77zN0ZTBLg=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/philhofer/fwd v1.1.1 h1:GdGcTjf5RNAxwS4QLsiMzJYj5KEvPJD3Abr261yRQXQ=
 github.com/philhofer/fwd v1.1.1/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=

--- a/iter.go
+++ b/iter.go
@@ -53,15 +53,6 @@ func (b *BondIterator) Exist(key []byte) bool {
 		return false
 	}
 
-	if b.batch != nil {
-		itr := b.batch.Iter(b.opt)
-		defer itr.Close()
-
-		if itr.SeekGE(key) && bytes.Equal(itr.Key(), key) {
-			return true
-		}
-	}
-
 	if !b.SeekGE(key) {
 		return false
 	}

--- a/iter.go
+++ b/iter.go
@@ -10,6 +10,7 @@ import (
 type IterOptions struct {
 	pebble.IterOptions
 	Filter Filter
+	Batch  Batch
 }
 
 type Iterator interface {
@@ -43,12 +44,11 @@ func pebbleIterOptions(opt *IterOptions) *pebble.IterOptions {
 type BondIterator struct {
 	*pebble.Iterator
 	filter Filter
-	batch  Batch
 	opt    *IterOptions
 }
 
 func (b *BondIterator) Exist(key []byte) bool {
-	bCtx := ContextWithBatch(context.Background(), b.batch)
+	bCtx := ContextWithBatch(context.Background(), b.opt.Batch)
 	if b.filter != nil && !b.filter.MayContain(bCtx, key) {
 		return false
 	}

--- a/keys.go
+++ b/keys.go
@@ -281,6 +281,10 @@ func (key KeyBytes) TableID() TableID {
 	return TableID(key[0])
 }
 
+func (key KeyBytes) PrimaryKey() []byte {
+	return key[10:]
+}
+
 func (key KeyBytes) IndexID() IndexID {
 	return IndexID(key[1])
 }

--- a/keys.go
+++ b/keys.go
@@ -281,10 +281,6 @@ func (key KeyBytes) TableID() TableID {
 	return TableID(key[0])
 }
 
-func (key KeyBytes) PrimaryKey() []byte {
-	return key[10:]
-}
-
 func (key KeyBytes) IndexID() IndexID {
 	return IndexID(key[1])
 }

--- a/options.go
+++ b/options.go
@@ -56,7 +56,7 @@ func DefaultPebbleOptions() *pebble.Options {
 		MemTableStopWritesThreshold: 4,
 		BlockPropertyCollectors: []func() pebble.BlockPropertyCollector{
 			func() pebble.BlockPropertyCollector {
-				return &BlockCollector{BlockMeta: NewBlockMeta()}
+				return &BlockCollector{blockRange: NewKeyRange(), tableRange: NewKeyRange()}
 			},
 		},
 	}

--- a/options.go
+++ b/options.go
@@ -54,6 +54,11 @@ func DefaultPebbleOptions() *pebble.Options {
 		MaxConcurrentCompactions:    func() int { return DefaultMaxConcurrentCompactions },
 		MemTableSize:                64 << 20, // 64 MB
 		MemTableStopWritesThreshold: 4,
+		BlockPropertyCollectors: []func() pebble.BlockPropertyCollector{
+			func() pebble.BlockPropertyCollector {
+				return &BlockCollector{BlockMeta: NewBlockMeta()}
+			},
+		},
 	}
 
 	opts.FlushDelayDeleteRange = 10 * time.Second

--- a/options.go
+++ b/options.go
@@ -66,6 +66,7 @@ func DefaultPebbleOptions() *pebble.Options {
 
 	opts.Experimental.MinDeletionRate = 128 << 20 // 128 MB
 	opts.Experimental.MaxWriterConcurrency = DefaultMaxWriterConcurrency
+	opts.FormatMajorVersion = pebble.FormatNewest
 
 	for i := 0; i < len(opts.Levels); i++ {
 		l := &opts.Levels[i]

--- a/options.go
+++ b/options.go
@@ -56,7 +56,11 @@ func DefaultPebbleOptions() *pebble.Options {
 		MemTableStopWritesThreshold: 4,
 		BlockPropertyCollectors: []func() pebble.BlockPropertyCollector{
 			func() pebble.BlockPropertyCollector {
-				return &BlockCollector{blockRange: NewKeyRange(), tableRange: NewKeyRange()}
+				return &BlockCollector{
+					blockRange: NewKeyRange(),
+					tableRange: NewKeyRange(),
+					indexRange: NewKeyRange(),
+				}
 			},
 		},
 	}

--- a/table.go
+++ b/table.go
@@ -311,7 +311,7 @@ func (t *_table[T]) getBlockFilter(trs []T) ([]T, [][]byte, *PrimaryKeyFilter, f
 	}
 
 	// sort the records since filter needs keys in sorted order
-	// for it's to intersect with block metadata.
+	// to intersect with block metadata.
 	sort.Sort(&utils.SortShim{
 		Length: len(keys),
 		SwapFn: func(i, j int) {

--- a/table.go
+++ b/table.go
@@ -390,7 +390,8 @@ func (t *_table[T]) Insert(ctx context.Context, trs []T, optBatch ...Batch) erro
 			PointKeyFilters: []pebble.BlockPropertyFilter{filter},
 		},
 		Filter: t.filter,
-	}, keyBatch)
+		Batch:  keyBatch,
+	})
 	defer itr.Close()
 
 	for i, tr := range trs {

--- a/table.go
+++ b/table.go
@@ -336,6 +336,10 @@ func (t *_table[T]) Insert(ctx context.Context, trs []T, optBatch ...Batch) erro
 		bufIdx += len(key)
 	}
 
+	sort.Slice(trs, func(i, j int) bool {
+		return bytes.Compare(keys[i], keys[j]) < 0
+	})
+
 	sort.Slice(keys, func(i, j int) bool {
 		return bytes.Compare(keys[i], keys[j]) < 0
 	})

--- a/table.go
+++ b/table.go
@@ -316,7 +316,7 @@ func (t *_table[T]) getBlockFilter(trs []T, keys [][]byte) ([]T, [][]byte, *Prim
 }
 
 func (t *_table[T]) keys(trs []T) ([][]byte, bool, func()) {
-	// The number of elements are predefined, so the cuckoo filter is efficient
+	// The total number of elements is predefined, so the cuckoo filter is efficient
 	// to check the possibility of key duplicate.
 	filter := cuckoo.NewFilter(uint(len(trs)))
 	duplicate := false
@@ -394,8 +394,7 @@ func (t *_table[T]) Insert(ctx context.Context, trs []T, optBatch ...Batch) erro
 			PointKeyFilters: []pebble.BlockPropertyFilter{filter},
 		},
 		Filter: t.filter,
-		Batch:  keyBatch,
-	})
+	}, keyBatch)
 	defer itr.Close()
 
 	for i, tr := range trs {

--- a/table.go
+++ b/table.go
@@ -316,15 +316,19 @@ func (t *_table[T]) getBlockFilter(trs []T, keys [][]byte) ([]T, [][]byte, *Prim
 }
 
 func (t *_table[T]) keys(trs []T) ([][]byte, bool, func()) {
-	keys := make([][]byte, len(trs))
-	keyBuffers := make([][]byte, len(trs))
+	// The number of elements are predefined, so the cuckoo filter is efficient
+	// to check the possibility of key duplicate.
 	filter := cuckoo.NewFilter(uint(len(trs)))
 	duplicate := false
+
+	keys := make([][]byte, len(trs))
+	keyBuffers := make([][]byte, len(trs))
 	for i, tr := range trs {
 		keyBuffer := _keyBufferPool.Get().([]byte)
 		keyBuffers[i] = keyBuffer
 		key := t.key(tr, keyBuffer[:])
 		keys[i] = key
+
 		if filter.Lookup(key) {
 			duplicate = true
 			continue

--- a/table.go
+++ b/table.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/pebble"
-	"github.com/cockroachdb/pebble/internal/base"
+
 	"github.com/go-bond/bond/utils"
 	"golang.org/x/exp/maps"
 )
@@ -345,7 +345,7 @@ func (t *_table[T]) Insert(ctx context.Context, trs []T, optBatch ...Batch) erro
 	itr := t.db.Iter(&IterOptions{
 		IterOptions: pebble.IterOptions{
 			KeyTypes:        pebble.IterKeyTypePointsOnly,
-			PointKeyFilters: []base.BlockPropertyFilter{filter},
+			PointKeyFilters: []pebble.BlockPropertyFilter{filter},
 		},
 	})
 	defer itr.Close()

--- a/table.go
+++ b/table.go
@@ -713,16 +713,13 @@ func (t *_table[T]) exist(key []byte, batch Batch, filter *PrimaryKeyFilter) boo
 		IterOptions: pebble.IterOptions{
 			PointKeyFilters: []pebble.BlockPropertyFilter{filter},
 			KeyTypes:        pebble.IterKeyTypePointsOnly,
+			LowerBound:      key,
+			UpperBound:      key,
 		},
 	}
 
 	itr := t.db.Iter(opt, batch)
 	defer itr.Close()
-
-	seeked := itr.SeekGE(key)
-	if !seeked {
-		return seeked
-	}
 	return bytes.Equal(itr.Key(), key)
 }
 
@@ -754,15 +751,12 @@ func (t *_table[T]) get(key []byte, batch Batch) (T, error) {
 		IterOptions: pebble.IterOptions{
 			PointKeyFilters: []pebble.BlockPropertyFilter{filter},
 			KeyTypes:        pebble.IterKeyTypePointsOnly,
+			LowerBound:      key,
+			UpperBound:      key,
 		},
 	}
 	itr := t.db.Iter(opt, batch)
 	defer itr.Close()
-
-	seeked := itr.SeekGE(key)
-	if !seeked {
-		return utils.MakeNew[T](), fmt.Errorf("not found")
-	}
 
 	if !bytes.Equal(itr.Key(), key) {
 		return utils.MakeNew[T](), fmt.Errorf("not found")

--- a/table.go
+++ b/table.go
@@ -328,13 +328,11 @@ func (t *_table[T]) Insert(ctx context.Context, trs []T, optBatch ...Batch) erro
 	defer _keyBufferPool.Put(indexKeysBuffer)
 
 	keys := make([][]byte, len(trs))
-	bufIdx := 0
 	for i, tr := range trs {
 		keyBuffer := _keyBufferPool.Get().([]byte)
 		defer _keyBufferPool.Put(keyBuffer)
-		key := t.key(tr, keyBuffer[:0])
+		key := t.key(tr, keyBuffer[:])
 		keys[i] = key
-		bufIdx += len(key)
 	}
 
 	sort.Slice(trs, func(i, j int) bool {

--- a/table.go
+++ b/table.go
@@ -328,7 +328,8 @@ func (t *_table[T]) Insert(ctx context.Context, trs []T, optBatch ...Batch) erro
 	defer _keyBufferPool.Put(indexKeysBuffer)
 
 	filter := &PrimaryKeyFilter{
-		ID: t.id,
+		ID:        t.id,
+		BlockMeta: NewBlockMeta(),
 	}
 
 	for _, tr := range trs {

--- a/table.go
+++ b/table.go
@@ -342,7 +342,6 @@ func (t *_table[T]) Insert(ctx context.Context, trs []T, optBatch ...Batch) erro
 		// insert key
 		key := t.key(tr, keyBuffer[:0])
 
-		filter.Key = key
 		// check if exist
 		if t.existNew(key, keyBatch, filter) {
 			return fmt.Errorf("record: %x already exist", key[_KeyPrefixSplitIndex(key):])
@@ -725,6 +724,8 @@ func (t *_table[T]) existNew(key []byte, batch Batch, filter *PrimaryKeyFilter) 
 		return false
 	}
 
+	filter.Key = KeyBytes(key).PrimaryKey()
+
 	opt := &IterOptions{
 		IterOptions: pebble.IterOptions{
 			PointKeyFilters: []pebble.BlockPropertyFilter{filter},
@@ -765,7 +766,7 @@ func (t *_table[T]) Get(tr T, optBatch ...Batch) (T, error) {
 func (t *_table[T]) get(key []byte, batch Batch) (T, error) {
 	filter := primaryFilterPool.Get().(*PrimaryKeyFilter)
 	filter.ID = t.id
-	filter.Key = key
+	filter.Key = KeyBytes(key).PrimaryKey()
 
 	opt := &IterOptions{
 		IterOptions: pebble.IterOptions{

--- a/table.go
+++ b/table.go
@@ -296,7 +296,6 @@ func (t *_table[T]) reindex(idxs []*Index[T]) error {
 }
 
 func (t *_table[T]) getBlockFilter(trs []T, keys [][]byte) ([]T, [][]byte, *PrimaryKeyFilter) {
-
 	// sort the records since the filter needs keys in sorted order
 	// to intersect with block metadata.
 	sort.Sort(&utils.SortShim{

--- a/table.go
+++ b/table.go
@@ -310,7 +310,7 @@ func (t *_table[T]) getBlockFilter(trs []T) ([]T, [][]byte, *PrimaryKeyFilter, f
 		}
 	}
 
-	// sort the records since filter needs keys in sorted order
+	// sort the records since the filter needs keys in sorted order
 	// to intersect with block metadata.
 	sort.Sort(&utils.SortShim{
 		Length: len(keys),

--- a/table.go
+++ b/table.go
@@ -792,13 +792,12 @@ func (t *_table[T]) get(key []byte, batch Batch) (T, error) {
 		IterOptions: pebble.IterOptions{
 			PointKeyFilters: []pebble.BlockPropertyFilter{filter},
 			KeyTypes:        pebble.IterKeyTypePointsOnly,
-			LowerBound:      key,
 		},
 	}
 	itr := t.db.Iter(opt, batch)
 	defer itr.Close()
 
-	if !itr.First() {
+	if !itr.SeekGE(key) {
 		return utils.MakeNew[T](), fmt.Errorf("not found")
 	}
 

--- a/table.go
+++ b/table.go
@@ -363,6 +363,12 @@ func (t *_table[T]) Insert(ctx context.Context, trs []T, optBatch ...Batch) erro
 
 	trs, keys, filter, keyBufferCloser := t.getBlockFilter(trs)
 	defer keyBufferCloser()
+
+	idx, exist := utils.Duplicate(keys)
+	if exist {
+		return fmt.Errorf("record: %x already exist", keys[idx][_KeyPrefixSplitIndex(keys[idx]):])
+	}
+
 	itr := t.db.Iter(&IterOptions{
 		IterOptions: pebble.IterOptions{
 			KeyTypes:        pebble.IterKeyTypePointsOnly,

--- a/table_test.go
+++ b/table_test.go
@@ -174,6 +174,9 @@ func TestBondTable_Insert(t *testing.T) {
 	err := tokenBalanceTable.Insert(context.Background(), []*TokenBalance{tokenBalanceAccount1})
 	require.NoError(t, err)
 
+	err = tokenBalanceTable.Insert(context.Background(), []*TokenBalance{tokenBalanceAccount1})
+	require.Error(t, err)
+
 	it := tokenBalanceTable.Iter(nil)
 
 	for it.First(); it.Valid(); it.Next() {

--- a/table_test.go
+++ b/table_test.go
@@ -246,7 +246,10 @@ func TestBondTable_Insert_When_Exist(t *testing.T) {
 		Balance:         5,
 	}
 
-	err := tokenBalanceTable.Insert(context.Background(), []*TokenBalance{tokenBalanceAccount1})
+	err := tokenBalanceTable.Insert(context.Background(), []*TokenBalance{tokenBalanceAccount1, tokenBalanceAccount1})
+	require.Error(t, err)
+
+	err = tokenBalanceTable.Insert(context.Background(), []*TokenBalance{tokenBalanceAccount1})
 	require.NoError(t, err)
 
 	err = tokenBalanceTable.Insert(context.Background(), []*TokenBalance{tokenBalanceAccount1})

--- a/utils/common.go
+++ b/utils/common.go
@@ -1,0 +1,11 @@
+package utils
+
+func Copy(dst []byte, src []byte) []byte {
+	if len(dst) >= len(src) {
+		copy(dst, src)
+		return dst[:len(src)]
+	}
+	dst = make([]byte, len(src))
+	copy(dst, src)
+	return dst
+}

--- a/utils/common.go
+++ b/utils/common.go
@@ -1,5 +1,7 @@
 package utils
 
+import "bytes"
+
 func Copy(dst []byte, src []byte) []byte {
 	if len(dst) >= len(src) {
 		copy(dst, src)
@@ -26,4 +28,15 @@ func (s *SortShim) Swap(i, j int) {
 
 func (s *SortShim) Less(i, j int) bool {
 	return s.LessFn(i, j)
+}
+
+func Duplicate(arr [][]byte) (int, bool) {
+	start := 0
+	for start < len(arr) && start+1 < len(arr) {
+		if bytes.Equal(arr[start], arr[start+1]) {
+			return start, true
+		}
+		start += 2
+	}
+	return 0, false
 }

--- a/utils/common.go
+++ b/utils/common.go
@@ -9,3 +9,21 @@ func Copy(dst []byte, src []byte) []byte {
 	copy(dst, src)
 	return dst
 }
+
+type SortShim struct {
+	SwapFn func(i, j int)
+	Length int
+	LessFn func(i, j int) bool
+}
+
+func (s *SortShim) Len() int {
+	return s.Length
+}
+
+func (s *SortShim) Swap(i, j int) {
+	s.SwapFn(i, j)
+}
+
+func (s *SortShim) Less(i, j int) bool {
+	return s.LessFn(i, j)
+}

--- a/utils/common_test.go
+++ b/utils/common_test.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDuplicate(t *testing.T) {
+	arr := [][]byte{[]byte("a"), []byte("b"), []byte("c"), []byte("c")}
+	_, exist := Duplicate(arr)
+	require.True(t, exist)
+}


### PR DESCRIPTION
`BlockCollector` is introduced to collect `min` and `max` range of primary key in the SST blocks. The collected properties are used to check primary key existence while inserting new records. 

Here is the result of the benchmark:

```
// to benchmark
// go run main.go -n 3

// poonai/collector
// Total time taken to insert 7m50.195707895s
// Total time taken to insert 7m50.33076302s
// Total time taken to insert 7m45.402373542s

// poonai/read_benchmark (master with benchmark-related code change)
// Total time taken to insert 8m30.903019397s
// Total time taken to insert 8m42.107201495s
// Total time taken to insert 8m43.434306111s

```
