### PR TITLE
Fix: the Query.After skips first element #84

### DIFF
--- a/bloom/bloom_filter.go
+++ b/bloom/bloom_filter.go
@@ -59,7 +59,7 @@ func NewBloomFilter(n uint, fp float64, numOfBuckets int, keyPrefixes ...[]byte)
 	keyPrefix := bond.KeyEncode(bond.Key{
 		TableID:    0,
 		IndexID:    0,
-		IndexKey:   []byte{},
+		Index:      []byte{},
 		IndexOrder: []byte{},
 		PrimaryKey: []byte("bf_"),
 	})

--- a/keys_test.go
+++ b/keys_test.go
@@ -168,7 +168,7 @@ func TestKey_Encode_Decode(t *testing.T) {
 	key := Key{
 		TableID:    1,
 		IndexID:    1,
-		IndexKey:   []byte("indexKey"),
+		Index:      []byte("indexKey"),
 		IndexOrder: []byte{},
 		PrimaryKey: []byte("recordKey"),
 	}
@@ -183,7 +183,7 @@ func TestKey_ToKeyPrefix(t *testing.T) {
 	key := Key{
 		TableID:    1,
 		IndexID:    1,
-		IndexKey:   []byte("indexKey"),
+		Index:      []byte("indexKey"),
 		IndexOrder: []byte("orderKey"),
 		PrimaryKey: []byte("recordKey"),
 	}
@@ -191,7 +191,7 @@ func TestKey_ToKeyPrefix(t *testing.T) {
 	expectedPrefixKey := Key{
 		TableID:    1,
 		IndexID:    1,
-		IndexKey:   []byte("indexKey"),
+		Index:      []byte("indexKey"),
 		IndexOrder: []byte{},
 		PrimaryKey: []byte{},
 	}
@@ -211,7 +211,7 @@ func TestKey_ToDataKey(t *testing.T) {
 	key := Key{
 		TableID:    1,
 		IndexID:    1,
-		IndexKey:   []byte("indexKey"),
+		Index:      []byte("indexKey"),
 		IndexOrder: []byte("orderKey"),
 		PrimaryKey: []byte("recordKey"),
 	}
@@ -219,7 +219,7 @@ func TestKey_ToDataKey(t *testing.T) {
 	expectedTableKey := Key{
 		TableID:    1,
 		IndexID:    PrimaryIndexID,
-		IndexKey:   []byte{},
+		Index:      []byte{},
 		IndexOrder: []byte{},
 		PrimaryKey: []byte("recordKey"),
 	}
@@ -239,7 +239,7 @@ func TestKeyBytes(t *testing.T) {
 	keyStruct := Key{
 		TableID:    1,
 		IndexID:    2,
-		IndexKey:   []byte{0x01, 0x02},
+		Index:      []byte{0x01, 0x02},
 		IndexOrder: []byte{},
 		PrimaryKey: []byte{0x02, 0x01},
 	}
@@ -248,7 +248,7 @@ func TestKeyBytes(t *testing.T) {
 
 	assert.Equal(t, TableID(1), keyBytes.TableID())
 	assert.Equal(t, IndexID(2), keyBytes.IndexID())
-	assert.Equal(t, []byte{0x01, 0x02}, keyBytes.IndexKey())
+	assert.Equal(t, []byte{0x01, 0x02}, keyBytes.Index())
 }
 
 func Benchmark_KeyBuilder(b *testing.B) {

--- a/query_test.go
+++ b/query_test.go
@@ -392,6 +392,17 @@ func TestBond_Query_After(t *testing.T) {
 	err = query.Execute(context.Background(), &tokenBalances)
 	require.Nil(t, err)
 	require.Equal(t, 0, len(tokenBalances))
+
+	err = TokenBalanceTable.Delete(context.Background(), []*TokenBalance{tokenBalance3Account1})
+	require.NoError(t, err)
+
+	query = TokenBalanceTable.Query().
+		With(TokenBalanceOrderedIndex, &TokenBalance{AccountAddress: "0xtestAccount", Balance: math.MaxUint64}).
+		After(tokenBalance3Account1)
+
+	err = query.Execute(context.Background(), &tokenBalances)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(tokenBalances))
 }
 
 func TestBond_Query_After_With_Order_Error(t *testing.T) {

--- a/table.go
+++ b/table.go
@@ -881,7 +881,7 @@ func (t *_table[T]) key(tr T, buff []byte) []byte {
 	return KeyEncode(Key{
 		TableID:    t.id,
 		IndexID:    PrimaryIndexID,
-		IndexKey:   []byte{},
+		Index:      []byte{},
 		IndexOrder: []byte{},
 		PrimaryKey: primaryKey,
 	}, buff[len(primaryKey):len(primaryKey)])
@@ -893,7 +893,7 @@ func (t *_table[T]) keyPrefix(idx *Index[T], s T, buff []byte) []byte {
 	return KeyEncode(Key{
 		TableID:    t.id,
 		IndexID:    idx.IndexID,
-		IndexKey:   indexKey,
+		Index:      indexKey,
 		IndexOrder: []byte{},
 		PrimaryKey: []byte{},
 	}, indexKey[len(indexKey):])
@@ -909,7 +909,7 @@ func (t *_table[T]) indexKey(tr T, idx *Index[T], buff []byte) []byte {
 	return KeyEncode(Key{
 		TableID:    t.id,
 		IndexID:    idx.IndexID,
-		IndexKey:   indexKeyPart,
+		Index:      indexKeyPart,
 		IndexOrder: orderKeyPart,
 		PrimaryKey: primaryKey,
 	}, orderKeyPart[len(orderKeyPart):])


### PR DESCRIPTION
The Query.After skips first element when element passed to After has been deleted or modified in a way that changes its Index / IndexOrder part of the DB key.

Issue: https://github.com/horizon-games/issue-tracker/issues/9514