### PR TITLE
Fix: Query using wrong selector when Query.After used after Query.Filter

### DIFF
--- a/query.go
+++ b/query.go
@@ -12,13 +12,6 @@ import (
 // FilterFunc is the function template to be used for record filtering.
 type FilterFunc[R any] func(r R) bool
 
-// FilterAndIndex the pair of evaluable and index on which query is executed.
-type FilterAndIndex[R any] struct {
-	FilterFunc    FilterFunc[R]
-	Index         *Index[R]
-	IndexSelector R
-}
-
 // OrderLessFunc is the function template to be used for record sorting.
 type OrderLessFunc[R any] func(r, r2 R) bool
 
@@ -37,7 +30,7 @@ type Query[R any] struct {
 	index         *Index[R]
 	indexSelector R
 
-	queries       []FilterAndIndex[R]
+	filterFunc    FilterFunc[R]
 	orderLessFunc OrderLessFunc[R]
 	offset        uint64
 	limit         uint64
@@ -49,7 +42,7 @@ func newQuery[R any](t *_table[R], i *Index[R]) Query[R] {
 		table:         t,
 		index:         i,
 		indexSelector: utils.MakeNew[R](),
-		queries:       []FilterAndIndex[R]{},
+		filterFunc:    nil,
 		orderLessFunc: nil,
 		offset:        0,
 		limit:         0,
@@ -78,12 +71,7 @@ func (q Query[R]) With(idx *Index[R], selector R) Query[R] {
 // Filter adds additional filtering to the query. The conditions can be built with
 // structures that implement Evaluable interface.
 func (q Query[R]) Filter(filter FilterFunc[R]) Query[R] {
-	newWhere := make([]FilterAndIndex[R], 0, len(q.queries)+1)
-	q.queries = append(append(newWhere, q.queries...), FilterAndIndex[R]{
-		FilterFunc:    filter,
-		Index:         q.index,
-		IndexSelector: q.indexSelector,
-	})
+	q.filterFunc = filter
 	return q
 }
 
@@ -127,66 +115,55 @@ func (q Query[R]) Execute(ctx context.Context, r *[]R, optBatch ...Batch) error 
 		return fmt.Errorf("after can not be used with order")
 	}
 
-	if len(q.queries) == 0 {
-		q.queries = append([]FilterAndIndex[R]{
-			{
-				FilterFunc:    nil,
-				Index:         q.index,
-				IndexSelector: q.indexSelector,
-			},
-		})
-	}
-
 	var records []R
-	for _, query := range q.queries {
-		count := uint64(0)
-		skippedFirstRow := false
-		err := q.table.ScanIndexForEach(ctx, query.Index, query.IndexSelector, func(key KeyBytes, lazy Lazy[R]) (bool, error) {
-			if q.isAfter && !skippedFirstRow {
-				skippedFirstRow = true
+	count := uint64(0)
+	skippedFirstRow := false
+	err := q.table.ScanIndexForEach(ctx, q.index, q.indexSelector, func(key KeyBytes, lazy Lazy[R]) (bool, error) {
+		if q.isAfter && !skippedFirstRow {
+			skippedFirstRow = true
 
-				rowIdxKey := key.ToKey()
-				selIdxKey := KeyBytes(q.table.indexKey(q.indexSelector, query.Index, []byte{})).ToKey()
-				if bytes.Compare(selIdxKey.Index, rowIdxKey.Index) == 0 &&
-					bytes.Compare(selIdxKey.IndexOrder, rowIdxKey.IndexOrder) == 0 {
-					return true, nil
-				}
-			}
-
-			// check if can apply offset in here
-			if q.shouldApplyOffsetEarly() && q.offset > count {
-				count++
+			rowIdxKey := key.ToKey()
+			selIdxKey := KeyBytes(q.table.indexKey(q.indexSelector, q.index, []byte{})).ToKey()
+			if bytes.Compare(selIdxKey.Index, rowIdxKey.Index) == 0 &&
+				bytes.Compare(selIdxKey.IndexOrder, rowIdxKey.IndexOrder) == 0 &&
+				bytes.Compare(selIdxKey.PrimaryKey, rowIdxKey.PrimaryKey) == 0 {
 				return true, nil
 			}
+		}
 
-			// get and deserialize
-			record, err := lazy.Get()
-			if err != nil {
-				return false, err
-			}
+		// check if can apply offset in here
+		if q.shouldApplyOffsetEarly() && q.offset > count {
+			count++
+			return true, nil
+		}
 
-			// filter if filter available
-			if q.shouldFilter(query) {
-				if query.FilterFunc(record) {
-					records = append(records, record)
-					count++
-				}
-			} else {
+		// get and deserialize
+		record, err := lazy.Get()
+		if err != nil {
+			return false, err
+		}
+
+		// filter if filter available
+		if q.shouldFilter() {
+			if q.filterFunc(record) {
 				records = append(records, record)
 				count++
 			}
-
-			next := true
-			// check if we need to iterate further
-			if !q.shouldSort() && q.shouldLimit() {
-				next = count < q.offset+q.limit
-			}
-
-			return next, nil
-		}, optBatch...)
-		if err != nil {
-			return err
+		} else {
+			records = append(records, record)
+			count++
 		}
+
+		next := true
+		// check if we need to iterate further
+		if !q.shouldSort() && q.shouldLimit() {
+			next = count < q.offset+q.limit
+		}
+
+		return next, nil
+	}, optBatch...)
+	if err != nil {
+		return err
 	}
 
 	// sorting
@@ -219,8 +196,8 @@ func (q Query[R]) Execute(ctx context.Context, r *[]R, optBatch ...Batch) error 
 	return nil
 }
 
-func (q Query[R]) shouldFilter(query FilterAndIndex[R]) bool {
-	return query.FilterFunc != nil
+func (q Query[R]) shouldFilter() bool {
+	return q.filterFunc != nil
 }
 
 func (q Query[R]) shouldSort() bool {
@@ -228,7 +205,7 @@ func (q Query[R]) shouldSort() bool {
 }
 
 func (q Query[R]) shouldApplyOffsetEarly() bool {
-	return q.orderLessFunc == nil && len(q.queries) == 1 && q.queries[0].FilterFunc == nil
+	return q.orderLessFunc == nil && q.filterFunc == nil
 }
 
 func (q Query[R]) shouldLimit() bool {
@@ -240,5 +217,5 @@ func (q Query[R]) isLimitApplied() bool {
 }
 
 func (q Query[R]) isOffsetApplied() bool {
-	return q.orderLessFunc == nil && len(q.queries) == 1 && q.queries[0].FilterFunc == nil
+	return q.orderLessFunc == nil && q.filterFunc == nil
 }

--- a/query_test.go
+++ b/query_test.go
@@ -403,6 +403,16 @@ func TestBond_Query_After(t *testing.T) {
 	err = query.Execute(context.Background(), &tokenBalances)
 	require.Nil(t, err)
 	require.Equal(t, 1, len(tokenBalances))
+
+	query = TokenBalanceTable.Query().
+		With(TokenBalanceOrderedIndex, &TokenBalance{AccountAddress: "0xtestAccount", Balance: math.MaxUint64}).
+		Filter(func(r *TokenBalance) bool {
+			return r.AccountAddress == "0xtestAccount"
+		}).After(tokenBalance3Account1)
+
+	err = query.Execute(context.Background(), &tokenBalances)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(tokenBalances))
 }
 
 func TestBond_Query_After_With_Order_Error(t *testing.T) {


### PR DESCRIPTION
- removed multiple queries support (not used, not fully implemented)
- made sure that we skip first element that is exactly the same as after element
- made sure that we always use proper selector in Table.ScanIndexForEach and Skip function
- added assertion to test for failing scenario