### PR TITLE
Table batched

### DIFF
--- a/_benchmarks/suites/table_scan_suite.go
+++ b/_benchmarks/suites/table_scan_suite.go
@@ -245,6 +245,7 @@ func ScanSkipThrough(tbt bond.Table[*TokenBalance], numberToSkip int, numberToRe
 	return func(b *testing.B) {
 		b.ReportAllocs()
 
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var counter = 0
 			var tokenBalances []*TokenBalance
@@ -277,6 +278,7 @@ func ScanIndexSkipThrough(tbt bond.Table[*TokenBalance], idx *bond.Index[*TokenB
 	return func(b *testing.B) {
 		b.ReportAllocs()
 
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var counter = 1
 			var tokenBalances []*TokenBalance

--- a/keys.go
+++ b/keys.go
@@ -304,12 +304,8 @@ func (key KeyBytes) ToKey() Key {
 
 func DefaultKeyComparer() *pebble.Comparer {
 	comparer := *pebble.DefaultComparer
-	comparer.Split = _KeyPrefixSplitIndexFullKey
+	comparer.Split = _KeyPrefixSplitIndex
 	return &comparer
-}
-
-func _KeyPrefixSplitIndexFullKey(rawKey []byte) int {
-	return len(rawKey) - 1
 }
 
 func _KeyPrefixSplitIndex(rawKey []byte) int {

--- a/keys.go
+++ b/keys.go
@@ -304,8 +304,12 @@ func (key KeyBytes) ToKey() Key {
 
 func DefaultKeyComparer() *pebble.Comparer {
 	comparer := *pebble.DefaultComparer
-	comparer.Split = _KeyPrefixSplitIndex
+	comparer.Split = _KeyPrefixSplitIndexFullKey
 	return &comparer
+}
+
+func _KeyPrefixSplitIndexFullKey(rawKey []byte) int {
+	return len(rawKey) - 1
 }
 
 func _KeyPrefixSplitIndex(rawKey []byte) int {

--- a/keys_test.go
+++ b/keys_test.go
@@ -174,8 +174,22 @@ func TestKey_Encode_Decode(t *testing.T) {
 	}
 
 	keyRaw := KeyEncode(key)
+	keyRawDirect := KeyEncodeRaw(
+		key.TableID,
+		key.IndexID,
+		func(buff []byte) []byte {
+			return append(buff, key.Index...)
+		},
+		func(buff []byte) []byte {
+			return append(buff, key.IndexOrder...)
+		},
+		func(buff []byte) []byte {
+			return append(buff, key.PrimaryKey...)
+		},
+	)
 	keyReconstructed := KeyDecode(keyRaw)
 
+	assert.Equal(t, keyRaw, keyRawDirect)
 	assert.Equal(t, key, keyReconstructed)
 }
 
@@ -205,6 +219,10 @@ func TestKey_ToKeyPrefix(t *testing.T) {
 	assert.Equal(t, true, keyPrefix.IsIndexKey())
 	assert.Equal(t, true, keyPrefix.IsKeyPrefix())
 	assert.Equal(t, expectedKeyPrefix, KeyEncode(keyPrefix))
+	assert.Equal(t, expectedKeyPrefix, KeyEncodeRaw(
+		key.TableID, key.IndexID, func(buff []byte) []byte {
+			return append(buff, key.Index...)
+		}, nil, nil))
 }
 
 func TestKey_ToDataKey(t *testing.T) {

--- a/query.go
+++ b/query.go
@@ -122,8 +122,14 @@ func (q Query[R]) Execute(ctx context.Context, r *[]R, optBatch ...Batch) error 
 		if q.isAfter && !skippedFirstRow {
 			skippedFirstRow = true
 
+			keyBuffer := _keyBufferPool.Get().([]byte)
+			defer _keyBufferPool.Put(keyBuffer)
+
+			keyPartsBuffer := _keyBufferPool.Get().([]byte)
+			defer _keyBufferPool.Put(keyPartsBuffer)
+
 			rowIdxKey := key.ToKey()
-			selIdxKey := KeyBytes(q.table.indexKey(q.indexSelector, q.index, []byte{})).ToKey()
+			selIdxKey := KeyBytes(q.table.indexKey(q.indexSelector, q.index, keyBuffer[:0], keyPartsBuffer[:0])).ToKey()
 			if bytes.Compare(selIdxKey.Index, rowIdxKey.Index) == 0 &&
 				bytes.Compare(selIdxKey.IndexOrder, rowIdxKey.IndexOrder) == 0 &&
 				bytes.Compare(selIdxKey.PrimaryKey, rowIdxKey.PrimaryKey) == 0 {

--- a/query.go
+++ b/query.go
@@ -125,11 +125,8 @@ func (q Query[R]) Execute(ctx context.Context, r *[]R, optBatch ...Batch) error 
 			keyBuffer := _keyBufferPool.Get().([]byte)
 			defer _keyBufferPool.Put(keyBuffer)
 
-			keyPartsBuffer := _keyBufferPool.Get().([]byte)
-			defer _keyBufferPool.Put(keyPartsBuffer)
-
 			rowIdxKey := key.ToKey()
-			selIdxKey := KeyBytes(q.table.indexKey(q.indexSelector, q.index, keyBuffer[:0], keyPartsBuffer[:0])).ToKey()
+			selIdxKey := KeyBytes(q.table.indexKey(q.indexSelector, q.index, keyBuffer[:0])).ToKey()
 			if bytes.Compare(selIdxKey.Index, rowIdxKey.Index) == 0 &&
 				bytes.Compare(selIdxKey.IndexOrder, rowIdxKey.IndexOrder) == 0 &&
 				bytes.Compare(selIdxKey.PrimaryKey, rowIdxKey.PrimaryKey) == 0 {

--- a/query.go
+++ b/query.go
@@ -122,8 +122,8 @@ func (q Query[R]) Execute(ctx context.Context, r *[]R, optBatch ...Batch) error 
 		if q.isAfter && !skippedFirstRow {
 			skippedFirstRow = true
 
-			keyBuffer := _keyBufferPool.Get().([]byte)
-			defer _keyBufferPool.Put(keyBuffer)
+			keyBuffer := q.table.db.getKeyBufferPool().Get()
+			defer q.table.db.getKeyBufferPool().Put(keyBuffer)
 
 			rowIdxKey := key.ToKey()
 			selIdxKey := KeyBytes(q.table.indexKey(q.indexSelector, q.index, keyBuffer[:0])).ToKey()

--- a/serializer.go
+++ b/serializer.go
@@ -1,5 +1,9 @@
 package bond
 
+import (
+	"bytes"
+)
+
 type Serializer[T any] interface {
 	Serialize(t T) ([]byte, error)
 	Deserialize(b []byte, t T) error
@@ -7,6 +11,10 @@ type Serializer[T any] interface {
 
 type SerializerWithClosable[T any] interface {
 	SerializerWithCloseable(t T) ([]byte, func(), error)
+}
+
+type SerializerWithBuffer[T any] interface {
+	SerializeFuncWithBuffer(buff *bytes.Buffer) func(T any) ([]byte, error)
 }
 
 type SerializerAnyWrapper[T any] struct {

--- a/serializers/cbor.go
+++ b/serializers/cbor.go
@@ -1,6 +1,8 @@
 package serializers
 
 import (
+	"bytes"
+
 	"github.com/fxamacker/cbor/v2"
 )
 
@@ -21,4 +23,21 @@ func (c *CBORSerializer) Deserialize(b []byte, i interface{}) error {
 		return c.DecMode.Unmarshal(b, i)
 	}
 	return cbor.Unmarshal(b, i)
+}
+
+func (c *CBORSerializer) SerializeFuncWithBuffer(buff *bytes.Buffer) func(T any) ([]byte, error) {
+	var encoder *cbor.Encoder
+	if c.EncMode != nil {
+		encoder = c.EncMode.NewEncoder(buff)
+	} else {
+		encoder = cbor.NewEncoder(buff)
+	}
+
+	return func(v any) ([]byte, error) {
+		buff.Reset()
+		if err := encoder.Encode(v); err != nil {
+			return nil, err
+		}
+		return buff.Bytes(), nil
+	}
 }

--- a/table.go
+++ b/table.go
@@ -1276,17 +1276,17 @@ func (t *_table[T]) indexKeysDiff(newTr T, oldTr T, idxs map[IndexID]*Index[T], 
 	return
 }
 
-func batched[T any](allItems []T, batchSize int, f func(batch []T) error) error {
+func batched[T any](items []T, batchSize int, f func(batch []T) error) error {
 	batchNum := 0
-	allItemsLen := len(allItems)
-	for batchNum*batchSize < allItemsLen {
+	itemsLen := len(items)
+	for batchNum*batchSize < itemsLen {
 		start := batchNum * batchSize
 		end := start + batchSize
-		if end > allItemsLen {
-			end = start + allItemsLen%batchSize
+		if end > itemsLen {
+			end = start + itemsLen%batchSize
 		}
 
-		err := f(allItems[start:end])
+		err := f(items[start:end])
 		if err != nil {
 			return err
 		}

--- a/table.go
+++ b/table.go
@@ -529,6 +529,9 @@ func (t *_table[T]) Update(ctx context.Context, trs []T, optBatch ...Batch) erro
 		serialize = sw.SerializeFuncWithBuffer(valueBuffer)
 	}
 
+	// reusable object
+	var oldTr T
+
 	err := batched[T](trs, persistentBatchSize, func(trs []T) error {
 		// keys
 		keys := t.keysExternal(trs, keysBuffer, keyPartsBuffer[:0])
@@ -562,7 +565,6 @@ func (t *_table[T]) Update(ctx context.Context, trs []T, optBatch ...Batch) erro
 				return fmt.Errorf("record: %x not found", key[_KeyPrefixSplitIndex(key):])
 			}
 
-			var oldTr T
 			err := t.serializer.Deserialize(iter.Value(), &oldTr)
 			if err != nil {
 				return err
@@ -725,6 +727,9 @@ func (t *_table[T]) Upsert(ctx context.Context, trs []T, onConflict func(old, ne
 		serialize = sw.SerializeFuncWithBuffer(valueBuffer)
 	}
 
+	// reusable object
+	var oldTr T
+
 	err := batched[T](trs, persistentBatchSize, func(trs []T) error {
 		// keys
 		keys := t.keysExternal(trs, keysBuffer, keyPartsBuffer)
@@ -754,7 +759,6 @@ func (t *_table[T]) Upsert(ctx context.Context, trs []T, onConflict func(old, ne
 
 			// old record
 			var (
-				oldTr    T
 				isUpdate bool
 				err      error
 			)

--- a/table.go
+++ b/table.go
@@ -16,19 +16,19 @@ import (
 
 var _keyBufferPool = utils.NewPreAllocatedPool[any](func() any {
 	return make([]byte, 0, KeyBufferInitialSize)
-}, 5*persistentBatchSize) // 51 MB
+}, 2*persistentBatchSize) // 51 MB
 
 var _multiKeyBufferPool = utils.NewPreAllocatedPool[any](func() any {
 	return make([]byte, 0, KeyBufferInitialSize*1000)
-}, 25) // 51 MB
+}, 10) // 51 MB
 
 var _byteArraysPool = utils.NewPreAllocatedPool[any](func() any {
 	return make([][]byte, 0, persistentBatchSize)
-}, 500) // 20 MB
+}, 50) // 20 MB
 
 var _valueBufferPool = utils.NewPreAllocatedPool[any](func() any {
 	return make([]byte, 0, ValueBufferInitialSize)
-}, 100*DefaultScanPrefetchSize) // 20 MB
+}, 10*DefaultScanPrefetchSize) // 20 MB
 
 func _valueBuffersGet(numOfKeys int) [][]byte {
 	keys := _byteArraysPool.Get().([][]byte)[:0]

--- a/table.go
+++ b/table.go
@@ -391,7 +391,7 @@ func (t *_table[T]) Insert(ctx context.Context, trs []T, optBatch ...Batch) erro
 		iter := t.db.Iter(&IterOptions{
 			IterOptions: pebble.IterOptions{
 				LowerBound: keys[0],
-				UpperBound: []byte{byte(t.id), 0x01},
+				UpperBound: []byte{byte(t.id), 0x01, 0x00, 0x00, 0x00, 0x00},
 			},
 		}, keyBatch)
 		defer iter.Close()
@@ -498,7 +498,7 @@ func (t *_table[T]) Update(ctx context.Context, trs []T, optBatch ...Batch) erro
 		iter := t.db.Iter(&IterOptions{
 			IterOptions: pebble.IterOptions{
 				LowerBound: keys[0],
-				UpperBound: []byte{byte(t.id), 0x01},
+				UpperBound: []byte{byte(t.id), 0x01, 0x00, 0x00, 0x00, 0x00},
 			},
 		}, keyBatch)
 		defer iter.Close()
@@ -690,7 +690,7 @@ func (t *_table[T]) Upsert(ctx context.Context, trs []T, onConflict func(old, ne
 		iter := t.db.Iter(&IterOptions{
 			IterOptions: pebble.IterOptions{
 				LowerBound: keys[0],
-				UpperBound: []byte{byte(t.id), 0x01},
+				UpperBound: []byte{byte(t.id), 0x01, 0x00, 0x00, 0x00, 0x00},
 			},
 		}, keyBatch)
 		defer iter.Close()
@@ -834,7 +834,7 @@ func (t *_table[T]) exist(key []byte, batch Batch, iter Iterator) bool {
 		iter = t.db.Iter(&IterOptions{
 			IterOptions: pebble.IterOptions{
 				LowerBound: key,
-				UpperBound: []byte{byte(t.id), 0x01},
+				UpperBound: []byte{byte(t.id), 0x01, 0x00, 0x00, 0x00, 0x00},
 			},
 		}, batch)
 		defer iter.Close()
@@ -886,7 +886,7 @@ func (t *_table[T]) get(keys [][]byte, batch Batch) ([][]byte, func(), error) {
 	iter := t.db.Iter(&IterOptions{
 		IterOptions: pebble.IterOptions{
 			LowerBound: keys[0],
-			UpperBound: []byte{byte(t.id), 0x01},
+			UpperBound: []byte{byte(t.id), 0x01, 0x00, 0x00, 0x00, 0x00},
 		},
 	}, batch)
 	defer iter.Close()

--- a/table_unsafe.go
+++ b/table_unsafe.go
@@ -37,16 +37,16 @@ func (t *_table[T]) UnsafeUpdate(ctx context.Context, trs []T, oldTrs []T, optBa
 
 	// key
 	var (
-		keyBuffer      = _keyBufferPool.Get().([]byte)
-		indexKeyBuffer = _multiKeyBufferPool.Get().([]byte)
+		keyBuffer      = t.db.getKeyBufferPool().Get()
+		indexKeyBuffer = t.db.getMultiKeyBufferPool().Get()
 	)
-	defer _keyBufferPool.Put(keyBuffer)
-	defer _keyBufferPool.Put(indexKeyBuffer)
+	defer t.db.getKeyBufferPool().Put(keyBuffer)
+	defer t.db.getMultiKeyBufferPool().Put(indexKeyBuffer)
 
 	// value
-	value := _valueBufferPool.Get().([]byte)[:0]
+	value := t.db.getValueBufferPool().Get()[:0]
 	valueBuffer := bytes.NewBuffer(value)
-	defer _valueBufferPool.Put(value)
+	defer t.db.getValueBufferPool().Put(value)
 
 	// serializer
 	var serialize = t.serializer.Serializer.Serialize

--- a/table_unsafe.go
+++ b/table_unsafe.go
@@ -38,13 +38,10 @@ func (t *_table[T]) UnsafeUpdate(ctx context.Context, trs []T, oldTrs []T, optBa
 	// key
 	var (
 		keyBuffer      = _keyBufferPool.Get().([]byte)
-		indexKeyBuffer = _keyBufferPool.Get().([]byte)
+		indexKeyBuffer = _multiKeyBufferPool.Get().([]byte)
 	)
 	defer _keyBufferPool.Put(keyBuffer)
 	defer _keyBufferPool.Put(indexKeyBuffer)
-
-	keyPartsBuffer := _keyBufferPool.Get().([]byte)
-	defer _keyBufferPool.Put(keyPartsBuffer)
 
 	// value
 	value := _valueBufferPool.Get().([]byte)[:0]
@@ -68,7 +65,7 @@ func (t *_table[T]) UnsafeUpdate(ctx context.Context, trs []T, oldTrs []T, optBa
 		}
 
 		// update key
-		key := t.key(tr, keyBuffer[:0], keyPartsBuffer[:0])
+		key := t.key(tr, keyBuffer[:0])
 
 		// serialize
 		data, err := serialize(&tr)
@@ -84,7 +81,7 @@ func (t *_table[T]) UnsafeUpdate(ctx context.Context, trs []T, oldTrs []T, optBa
 		}
 
 		// indexKeys to add and remove
-		toAddIndexKeys, toRemoveIndexKeys := t.indexKeysDiff(tr, oldTr, indexes, indexKeyBuffer[:0], keyPartsBuffer[:0])
+		toAddIndexKeys, toRemoveIndexKeys := t.indexKeysDiff(tr, oldTr, indexes, indexKeyBuffer[:0])
 
 		// update indexes
 		for _, indexKey := range toAddIndexKeys {

--- a/utils/sync.go
+++ b/utils/sync.go
@@ -64,7 +64,7 @@ func (s *PreAllocatedPool[T]) Put(t T) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if itemsLen := len(s.preAllocItems); itemsLen < s.preAllocItemsSize {
+	if len(s.preAllocItems) < s.preAllocItemsSize {
 		s.preAllocItems = append(s.preAllocItems, t)
 	} else {
 		s.Pool.Put(t)

--- a/utils/sync.go
+++ b/utils/sync.go
@@ -18,3 +18,44 @@ func (s *SyncPoolWrapper[T]) Get() T {
 func (s *SyncPoolWrapper[T]) Put(t T) {
 	s.Pool.Put(t)
 }
+
+type PreAllocatedPool[T any] struct {
+	*SyncPoolWrapper[T]
+
+	preAllocItems chan T
+}
+
+func NewPreAllocatedPool[T any](newFunc func() any, size int) *PreAllocatedPool[T] {
+	preAllocItems := make(chan T, size)
+	syncPool := &SyncPoolWrapper[T]{
+		Pool: sync.Pool{
+			New: newFunc,
+		},
+	}
+
+	for i := 0; i < size; i++ {
+		preAllocItems <- syncPool.Get()
+	}
+
+	return &PreAllocatedPool[T]{
+		SyncPoolWrapper: syncPool,
+		preAllocItems:   preAllocItems,
+	}
+}
+
+func (s *PreAllocatedPool[T]) Get() T {
+	select {
+	case item := <-s.preAllocItems:
+		return item
+	default:
+		return s.Pool.Get().(T)
+	}
+}
+
+func (s *PreAllocatedPool[T]) Put(t T) {
+	select {
+	case s.preAllocItems <- t:
+	default:
+		s.Pool.Put(t)
+	}
+}


### PR DESCRIPTION
Improvements:
- The PreAllocatedPools that store up to N of the items in the array and anything above that is Get/Put using SyncPool - it makes sure that we have some minimal number of buffers available from the start.
- The SerializerWithBuffer that allows serialization into a given buffer. It significantly decreases the number of allocations made during serialization.
- The new KeyEncodeRaw that requires smaller buffer / less buffers to construct the db key.
- The new batches Inserts/Updates/Upserts that process keys in an ordered way.
- The improvement to scanIndexForEachSecondary where we reuse an array of value buffers instead of getting a new one at each batch.

Benchmarks:
bond benchmark tool: 
[bond_master_vs_table_batched.xlsx](https://github.com/go-bond/bond/files/10977767/bond_master_vs_table_batched.xlsx)

immense_bench:  Batch 10000, TotalBatchNum, 80 Tables, 8 

master:
1m54.503454019s

table_batched:
31.452095176s


The changes are backward compatible.
