### PR TITLE
use bloom filter on get calls

### DIFF
--- a/table.go
+++ b/table.go
@@ -892,7 +892,7 @@ func (t *_table[T]) Get(ctx context.Context, sel Selector[T], optBatch ...Batch)
 		defer t.db.putKeyArray(valueArray)
 
 		var trs []T
-		err := batched[T](selPoints, t.scanPrefetchSize, func(selPoints []T) error {
+		err := batched[T](selPoints, len(selPoints), func(selPoints []T) error {
 			keys := t.keysExternal(selPoints, keyArray)
 
 			values, err := t.get(keys, batch, valueArray, false)

--- a/table_unsafe.go
+++ b/table_unsafe.go
@@ -101,3 +101,103 @@ func (t *_table[T]) UnsafeUpdate(ctx context.Context, trs []T, oldTrs []T, optBa
 
 	return nil
 }
+
+// TableUnsafeInserter provides access to UnsafeInsert method that allows to insert
+// records wihout checking if they already exist in the database.
+
+// Warning: The indices of the records won't be updated properly if the records already exist.
+type TableUnsafeInserter[T any] interface {
+	UnsafeInsert(ctx context.Context, trs []T, optBatch ...Batch) error
+}
+
+func (t *_table[T]) UnsafeInsert(ctx context.Context, trs []T, optBatch ...Batch) error {
+	t.mutex.RLock()
+	indexes := make(map[IndexID]*Index[T])
+	maps.Copy(indexes, t.secondaryIndexes)
+	t.mutex.RUnlock()
+
+	var (
+		batch         Batch
+		externalBatch = len(optBatch) > 0 && optBatch[0] != nil
+	)
+
+	if externalBatch {
+		batch = optBatch[0]
+	} else {
+		batch = t.db.Batch(BatchTypeWriteOnly)
+		defer batch.Close()
+	}
+
+	var (
+		indexKeyBuffer = t.db.getKeyBufferPool().Get()[:0]
+	)
+	defer t.db.getKeyBufferPool().Put(indexKeyBuffer[:0])
+
+	// key buffers
+	keysBuffer := t.db.getKeyArray(minInt(len(trs), persistentBatchSize))
+	defer t.db.putKeyArray(keysBuffer)
+
+	// value
+	value := t.db.getValueBufferPool().Get()[:0]
+	valueBuffer := bytes.NewBuffer(value)
+	defer t.db.getValueBufferPool().Put(value[:0])
+
+	// serializer
+	var serialize = t.serializer.Serializer.Serialize
+	if sw, ok := t.serializer.Serializer.(SerializerWithBuffer[any]); ok {
+		serialize = sw.SerializeFuncWithBuffer(valueBuffer)
+	}
+
+	err := batched[T](trs, persistentBatchSize, func(trs []T) error {
+		// keys
+		keys := t.keysExternal(trs, keysBuffer)
+
+		// process rows
+		for i, key := range keys {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("context done: %w", ctx.Err())
+			default:
+			}
+
+			tr := trs[i]
+			// serialize
+			data, err := serialize(&tr)
+			if err != nil {
+				return err
+			}
+
+			err = batch.Set(key, data, Sync)
+			if err != nil {
+				return err
+			}
+
+			// index keys
+			for _, idx := range indexes {
+				err = idx.OnInsert(t, tr, batch, indexKeyBuffer[:0])
+				if err != nil {
+					return err
+				}
+			}
+
+			// add to bloom filter
+			if t.filter != nil {
+				t.filter.Add(ctx, key)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if !externalBatch {
+		err = batch.Commit(Sync)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/table_unsafe_test.go
+++ b/table_unsafe_test.go
@@ -90,7 +90,7 @@ func TestBondTable_UnsafeUpdate(t *testing.T) {
 	_ = it.Close()
 }
 
-func TestUnsafeInsert(t *testing.T) {
+func TestBondTable_UnsafeInsert(t *testing.T) {
 	db := setupDatabase()
 	defer tearDownDatabase(db)
 


### PR DESCRIPTION
1) bloom filters are used in `get` call

2) The keys were sorted in both `get` and `Get` call. The unnecessary sort in `Get` call has been removed. 
