### PR TITLE
update ci to use go 1.23.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.1
+        go-version: 1.23.0
 
     - name: Build Example
       run: go build -v ./_examples/simple/...


### PR DESCRIPTION
we should use matrix and test against 1.22, 1.23