### PR TITLE
bond: refactor buffer pool API with cap guards to prevent memory bloat

### DIFF
--- a/bond.go
+++ b/bond.go
@@ -114,14 +114,17 @@ type Backup interface {
 type Closer io.Closer
 
 type internalPools interface {
-	getKeyBufferPool() utils.SyncPool[[]byte]
-	getMultiKeyBufferPool() utils.SyncPool[[]byte]
-	getValueBufferPool() utils.SyncPool[[]byte]
-	getBytesArrayPool() utils.SyncPool[[][]byte]
 	getKeyArray(numOfKeys int) [][]byte
 	putKeyArray(arr [][]byte)
 	getValueArray(numOfValues int) [][]byte
 	putValueArray(arr [][]byte)
+
+	getKeyBuffer() []byte
+	putKeyBuffer(key []byte)
+	getMultiKeyBuffer() []byte
+	putMultiKeyBuffer(key []byte)
+	getValueBuffer() []byte
+	putValueBuffer(value []byte)
 }
 
 type _db struct {
@@ -340,22 +343,6 @@ func (db *_db) notifyOnClose() {
 	}
 }
 
-func (db *_db) getKeyBufferPool() utils.SyncPool[[]byte] {
-	return db.keyBufferPool
-}
-
-func (db *_db) getMultiKeyBufferPool() utils.SyncPool[[]byte] {
-	return db.multiKeyBufferPool
-}
-
-func (db *_db) getValueBufferPool() utils.SyncPool[[]byte] {
-	return db.valueBufferPool
-}
-
-func (db *_db) getBytesArrayPool() utils.SyncPool[[][]byte] {
-	return db.byteArraysPool
-}
-
 func (db *_db) getKeyArray(numOfKeys int) [][]byte {
 	keys := db.byteArraysPool.Get()
 	if cap(keys) < numOfKeys {
@@ -370,7 +357,7 @@ func (db *_db) getKeyArray(numOfKeys int) [][]byte {
 
 func (db *_db) putKeyArray(arr [][]byte) {
 	for _, key := range arr {
-		db.keyBufferPool.Put(key[:0])
+		db.putKeyBuffer(key[:0])
 	}
 	db.byteArraysPool.Put(arr[:0])
 }
@@ -389,9 +376,48 @@ func (db *_db) getValueArray(numOfValues int) [][]byte {
 
 func (db *_db) putValueArray(arr [][]byte) {
 	for _, value := range arr {
-		db.valueBufferPool.Put(value[:0])
+		db.putValueBuffer(value)
 	}
 	db.byteArraysPool.Put(arr[:0])
+}
+
+// getKeyBuffer gets a key buffer from the pool.
+func (db *_db) getKeyBuffer() []byte {
+	return db.keyBufferPool.Get()
+}
+
+// putKeyBuffer puts the key buffer back to the pool if it is small enough.
+// otherwise, discard it to avoid memory bloat.
+func (db *_db) putKeyBuffer(key []byte) {
+	if cap(key) <= 4*DefaultKeyBufferSize {
+		db.keyBufferPool.Put(key[:0])
+	}
+}
+
+// getMultiKeyBuffer gets a multi key buffer from the pool.
+func (db *_db) getMultiKeyBuffer() []byte {
+	return db.multiKeyBufferPool.Get()
+}
+
+// putMultiKeyBuffer puts the multi key buffer back to the pool if it is small enough.
+// otherwise, discard it to avoid memory bloat.
+func (db *_db) putMultiKeyBuffer(key []byte) {
+	if cap(key) <= 4*DefaultKeyBufferSize*DefaultNumberOfKeyBuffersInMultiKeyBuffer {
+		db.multiKeyBufferPool.Put(key[:0])
+	}
+}
+
+// getValueBuffer gets a value buffer from the pool.
+func (db *_db) getValueBuffer() []byte {
+	return db.valueBufferPool.Get()
+}
+
+// putValueBuffer puts the value buffer back to the pool if it is small enough.
+// otherwise, discard it to avoid memory bloat.
+func (db *_db) putValueBuffer(value []byte) {
+	if cap(value) <= 2*DefaultValueBufferSize {
+		db.valueBufferPool.Put(value[:0])
+	}
 }
 
 func (db *_db) Dump(_ context.Context, path string, tables []TableID, withIndex bool) error {

--- a/index.go
+++ b/index.go
@@ -205,17 +205,18 @@ func (idx *Index[T]) Iter(table Table[T], selector Selector[T], optBatch ...Batc
 		iterConstructor = optBatch[0]
 	}
 
-	keyBufferPool := table.DB().getKeyBufferPool()
+	keyBufferGet := table.DB().getKeyBuffer
+	keyBufferPut := table.DB().putKeyBuffer
 
 	switch selector.Type() {
 	case SelectorTypePoint:
 		sel := selector.(SelectorPoint[T])
-		lowerBound := encodeIndexKey(table, sel.Point(), idx, keyBufferPool.Get())
-		upperBound := keySuccessor(lowerBound[0:_KeyPrefix(lowerBound)], keyBufferPool.Get())
+		lowerBound := encodeIndexKey(table, sel.Point(), idx, keyBufferGet())
+		upperBound := keySuccessor(lowerBound[0:_KeyPrefix(lowerBound)], keyBufferGet())
 
 		releaseBuffers := func() {
-			keyBufferPool.Put(lowerBound[:0])
-			keyBufferPool.Put(upperBound[:0])
+			keyBufferPut(lowerBound[:0])
+			keyBufferPut(upperBound[:0])
 		}
 		return iterConstructor.Iter(&IterOptions{
 			IterOptions: pebble.IterOptions{
@@ -228,15 +229,15 @@ func (idx *Index[T]) Iter(table Table[T], selector Selector[T], optBatch ...Batc
 		sel := selector.(SelectorPoints[T])
 		var pebbleOpts []*IterOptions
 		for _, point := range sel.Points() {
-			lowerBound := encodeIndexKey(table, point, idx, keyBufferPool.Get())
-			upperBound := keySuccessor(lowerBound[0:_KeyPrefix(lowerBound)], keyBufferPool.Get())
+			lowerBound := encodeIndexKey(table, point, idx, keyBufferGet())
+			upperBound := keySuccessor(lowerBound[0:_KeyPrefix(lowerBound)], keyBufferGet())
 			if idx.IndexID == PrimaryIndexID {
 				upperBound = keySuccessor(lowerBound, upperBound[:0])
 			}
 
 			releaseBuffers := func() {
-				keyBufferPool.Put(lowerBound[:0])
-				keyBufferPool.Put(upperBound[:0])
+				keyBufferPut(lowerBound[:0])
+				keyBufferPut(upperBound[:0])
 			}
 
 			pebbleOpts = append(pebbleOpts, &IterOptions{
@@ -253,13 +254,13 @@ func (idx *Index[T]) Iter(table Table[T], selector Selector[T], optBatch ...Batc
 		sel := selector.(SelectorRange[T])
 		low, up := sel.Range()
 
-		lowerBound := encodeIndexKey(table, low, idx, keyBufferPool.Get())
-		upperBound := encodeIndexKey(table, up, idx, keyBufferPool.Get())
+		lowerBound := encodeIndexKey(table, low, idx, keyBufferGet())
+		upperBound := encodeIndexKey(table, up, idx, keyBufferGet())
 		upperBound = keySuccessor(upperBound, nil)
 
 		releaseBuffers := func() {
-			keyBufferPool.Put(lowerBound[:0])
-			keyBufferPool.Put(upperBound[:0])
+			keyBufferPut(lowerBound[:0])
+			keyBufferPut(upperBound[:0])
 		}
 		return iterConstructor.Iter(&IterOptions{
 			IterOptions: pebble.IterOptions{
@@ -274,13 +275,13 @@ func (idx *Index[T]) Iter(table Table[T], selector Selector[T], optBatch ...Batc
 		for _, r := range sel.Ranges() {
 			low, up := r[0], r[1]
 
-			lowerBound := encodeIndexKey(table, low, idx, keyBufferPool.Get())
-			upperBound := encodeIndexKey(table, up, idx, keyBufferPool.Get())
+			lowerBound := encodeIndexKey(table, low, idx, keyBufferGet())
+			upperBound := encodeIndexKey(table, up, idx, keyBufferGet())
 			upperBound = keySuccessor(upperBound, nil)
 
 			releaseBuffers := func() {
-				keyBufferPool.Put(lowerBound[:0])
-				keyBufferPool.Put(upperBound[:0])
+				keyBufferPut(lowerBound[:0])
+				keyBufferPut(upperBound[:0])
 			}
 			pebbleOpts = append(pebbleOpts, &IterOptions{
 				IterOptions: pebble.IterOptions{

--- a/query.go
+++ b/query.go
@@ -185,8 +185,8 @@ func (q Query[T]) executeQuery(ctx context.Context, optBatch ...Batch) ([]T, err
 			skippedFirstRow = true
 			afterApplied = true
 
-			keyBuffer := q.table.db.getKeyBufferPool().Get()
-			defer q.table.db.getKeyBufferPool().Put(keyBuffer[:0])
+			keyBuffer := q.table.db.getKeyBuffer()
+			defer q.table.db.putKeyBuffer(keyBuffer[:0])
 
 			rowIdxKey := key.ToKey()
 			selIdxKey := KeyBytes(encodeIndexKey(q.table, q.afterSelector, q.index, keyBuffer[:0])).ToKey()

--- a/table.go
+++ b/table.go
@@ -354,8 +354,8 @@ func (t *_table[T]) Insert(ctx context.Context, trs []T, optBatch ...Batch) erro
 		batchReadWrite = batch
 	}
 
-	indexKeyBuffer := t.db.getKeyBufferPool().Get()
-	defer t.db.getKeyBufferPool().Put(indexKeyBuffer[:0])
+	indexKeyBuffer := t.db.getKeyBuffer()
+	defer t.db.putKeyBuffer(indexKeyBuffer[:0])
 
 	// key buffers
 	batchSize := min(len(trs), persistentBatchSize)
@@ -363,9 +363,9 @@ func (t *_table[T]) Insert(ctx context.Context, trs []T, optBatch ...Batch) erro
 	defer t.db.putKeyArray(keysBuffer)
 
 	// value
-	value := t.db.getValueBufferPool().Get()
+	value := t.db.getValueBuffer()
 	valueBuffer := bytes.NewBuffer(value)
-	defer t.db.getValueBufferPool().Put(value[:0])
+	defer t.db.putValueBuffer(value[:0])
 
 	// serializer
 	var serialize = t.serializer.Serializer.Serialize
@@ -469,10 +469,10 @@ func (t *_table[T]) Update(ctx context.Context, trs []T, optBatch ...Batch) erro
 		batchReadWrite = batch
 	}
 
-	indexKeyBuffer := t.db.getKeyBufferPool().Get()
-	indexKeyBuffer2 := t.db.getKeyBufferPool().Get()
-	defer t.db.getKeyBufferPool().Put(indexKeyBuffer[:0])
-	defer t.db.getKeyBufferPool().Put(indexKeyBuffer2[:0])
+	indexKeyBuffer := t.db.getKeyBuffer()
+	indexKeyBuffer2 := t.db.getKeyBuffer()
+	defer t.db.putKeyBuffer(indexKeyBuffer[:0])
+	defer t.db.putKeyBuffer(indexKeyBuffer2[:0])
 
 	// key buffers
 	batchSize := min(len(trs), persistentBatchSize)
@@ -480,9 +480,9 @@ func (t *_table[T]) Update(ctx context.Context, trs []T, optBatch ...Batch) erro
 	defer t.db.putKeyArray(keysBuffer)
 
 	// value
-	value := t.db.getValueBufferPool().Get()
+	value := t.db.getValueBuffer()
 	valueBuffer := bytes.NewBuffer(value)
-	defer t.db.getValueBufferPool().Put(value[:0])
+	defer t.db.putValueBuffer(value[:0])
 
 	// serializer
 	var serialize = t.serializer.Serializer.Serialize
@@ -589,10 +589,10 @@ func (t *_table[T]) Delete(ctx context.Context, trs []T, optBatch ...Batch) erro
 		defer batch.Close()
 	}
 
-	keyBuffer := t.db.getKeyBufferPool().Get()
-	indexKeyBuffer := t.db.getKeyBufferPool().Get()
-	defer t.db.getKeyBufferPool().Put(keyBuffer[:0])
-	defer t.db.getKeyBufferPool().Put(indexKeyBuffer[:0])
+	keyBuffer := t.db.getKeyBuffer()
+	indexKeyBuffer := t.db.getKeyBuffer()
+	defer t.db.putKeyBuffer(keyBuffer[:0])
+	defer t.db.putKeyBuffer(indexKeyBuffer[:0])
 
 	for i, tr := range trs {
 		// Check every 100 iterations if context is done, with micro-optimization.
@@ -651,11 +651,11 @@ func (t *_table[T]) Upsert(ctx context.Context, trs []T, onConflict func(old, ne
 	}
 
 	var (
-		indexKeyBuffer  = t.db.getKeyBufferPool().Get()
-		indexKeyBuffer2 = t.db.getKeyBufferPool().Get()
+		indexKeyBuffer  = t.db.getKeyBuffer()
+		indexKeyBuffer2 = t.db.getKeyBuffer()
 	)
-	defer t.db.getKeyBufferPool().Put(indexKeyBuffer[:0])
-	defer t.db.getKeyBufferPool().Put(indexKeyBuffer2[:0])
+	defer t.db.putKeyBuffer(indexKeyBuffer[:0])
+	defer t.db.putKeyBuffer(indexKeyBuffer2[:0])
 
 	// key buffers
 	batchSize := min(len(trs), persistentBatchSize)
@@ -663,9 +663,9 @@ func (t *_table[T]) Upsert(ctx context.Context, trs []T, onConflict func(old, ne
 	defer t.db.putKeyArray(keysBuffer)
 
 	// value
-	value := t.db.getValueBufferPool().Get()
+	value := t.db.getValueBuffer()
 	valueBuffer := bytes.NewBuffer(value)
-	defer t.db.getValueBufferPool().Put(value[:0])
+	defer t.db.putValueBuffer(value[:0])
 
 	// serializer
 	var serialize = t.serializer.Serializer.Serialize
@@ -793,8 +793,8 @@ func (t *_table[T]) Exist(tr T, optBatch ...Batch) bool {
 		batch = nil
 	}
 
-	keyBuffer := t.db.getKeyBufferPool().Get()
-	defer t.db.getKeyBufferPool().Put(keyBuffer[:0])
+	keyBuffer := t.db.getKeyBuffer()
+	defer t.db.putKeyBuffer(keyBuffer[:0])
 
 	key := t.key(tr, keyBuffer[:0])
 
@@ -864,8 +864,8 @@ func (t *_table[T]) Get(ctx context.Context, sel Selector[T], optBatch ...Batch)
 	case SelectorTypePoint:
 		tr := sel.(SelectorPoint[T]).Point()
 
-		keyBuffer := t.db.getKeyBufferPool().Get()
-		defer t.db.getKeyBufferPool().Put(keyBuffer[:0])
+		keyBuffer := t.db.getKeyBuffer()
+		defer t.db.putKeyBuffer(keyBuffer[:0])
 
 		key := t.key(tr, keyBuffer[:0])
 
@@ -894,8 +894,8 @@ func (t *_table[T]) Get(ctx context.Context, sel Selector[T], optBatch ...Batch)
 		keyArray := t.db.getKeyArray(len(selPoints))
 		defer t.db.putKeyArray(keyArray)
 
-		valueArray := t.db.getKeyArray(len(selPoints))
-		defer t.db.putKeyArray(valueArray)
+		valueArray := t.db.getValueArray(len(selPoints))
+		defer t.db.putValueArray(valueArray)
 
 		var trs []T
 		err := batched(selPoints, len(selPoints), func(selPoints []T) error {
@@ -1100,14 +1100,14 @@ func (t *_table[T]) scanForEachSecondaryIndex(ctx context.Context, idx *Index[T]
 		batch = optBatch[0]
 	}
 
-	keys := t.db.getBytesArrayPool().Get()
-	indexKeys := t.db.getBytesArrayPool().Get()
-	multiKeyBuffer := t.db.getMultiKeyBufferPool().Get()
+	keys := t.db.getKeyArray(0)
+	indexKeys := t.db.getKeyArray(0)
+	multiKeyBuffer := t.db.getMultiKeyBuffer()
 	valuesBuffer := t.db.getValueArray(t.scanPrefetchSize)
 	defer func() {
-		t.db.getBytesArrayPool().Put(keys[:0])
-		t.db.getBytesArrayPool().Put(indexKeys[:0])
-		t.db.getMultiKeyBufferPool().Put(multiKeyBuffer[:0])
+		t.db.putKeyArray(keys[:0])
+		t.db.putKeyArray(indexKeys[:0])
+		t.db.putMultiKeyBuffer(multiKeyBuffer[:0])
 		t.db.putValueArray(valuesBuffer)
 	}()
 

--- a/table_unsafe.go
+++ b/table_unsafe.go
@@ -31,20 +31,20 @@ func (t *_table[T]) UnsafeUpdate(ctx context.Context, trs []T, oldTrs []T, optBa
 
 	// key
 	var (
-		keyBuffer       = t.db.getKeyBufferPool().Get()
-		indexKeyBuffer  = t.db.getKeyBufferPool().Get()
-		indexKeyBuffer2 = t.db.getKeyBufferPool().Get()
+		keyBuffer       = t.db.getKeyBuffer()
+		indexKeyBuffer  = t.db.getKeyBuffer()
+		indexKeyBuffer2 = t.db.getKeyBuffer()
 	)
 	defer func() {
-		t.db.getKeyBufferPool().Put(keyBuffer[:0])
-		t.db.getKeyBufferPool().Put(indexKeyBuffer[:0])
-		t.db.getKeyBufferPool().Put(indexKeyBuffer2[:0])
+		t.db.putKeyBuffer(keyBuffer[:0])
+		t.db.putKeyBuffer(indexKeyBuffer[:0])
+		t.db.putKeyBuffer(indexKeyBuffer2[:0])
 	}()
 
 	// value
-	value := t.db.getValueBufferPool().Get()
+	value := t.db.getValueBuffer()
 	valueBuffer := bytes.NewBuffer(value)
-	defer t.db.getValueBufferPool().Put(value[:0])
+	defer t.db.putValueBuffer(value[:0])
 
 	// serializer
 	var serialize = t.serializer.Serializer.Serialize
@@ -121,8 +121,8 @@ func (t *_table[T]) UnsafeInsert(ctx context.Context, trs []T, optBatch ...Batch
 		defer batch.Close()
 	}
 
-	indexKeyBuffer := t.db.getKeyBufferPool().Get()
-	defer t.db.getKeyBufferPool().Put(indexKeyBuffer[:0])
+	indexKeyBuffer := t.db.getKeyBuffer()
+	defer t.db.putKeyBuffer(indexKeyBuffer[:0])
 
 	// key buffers
 	batchSize := min(len(trs), persistentBatchSize)
@@ -130,9 +130,9 @@ func (t *_table[T]) UnsafeInsert(ctx context.Context, trs []T, optBatch ...Batch
 	defer t.db.putKeyArray(keysBuffer)
 
 	// value
-	value := t.db.getValueBufferPool().Get()
+	value := t.db.getValueBuffer()
 	valueBuffer := bytes.NewBuffer(value)
-	defer t.db.getValueBufferPool().Put(value[:0])
+	defer t.db.putValueBuffer(value[:0])
 
 	// serializer
 	var serialize = t.serializer.Serializer.Serialize


### PR DESCRIPTION
Replace raw pool accessors (getKeyBufferPool, getValueBufferPool, etc.) with get/put helper methods that enforce capacity limits before returning buffers to pools. Oversized buffers are discarded instead of recycled. Also fixes pool contamination bug in Get with SelectorTypePoints where value buffers were allocated from and returned to the key buffer pool.